### PR TITLE
Don't do DNS lookups each time we want to send metrics

### DIFF
--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -69,11 +69,11 @@ class NullTransport(object):
 class RawTransport(object):
     """A transport which sends messages on a socket."""
     def __init__(self, endpoint):
-        self.address = endpoint.address
         self.socket = socket.socket(endpoint.family, socket.SOCK_DGRAM)
+        self.socket.connect(endpoint.address)
 
     def send(self, serialized_metric):
-        self.socket.sendto(serialized_metric, self.address)
+        self.socket.send(serialized_metric)
 
 
 class BufferedTransport(object):

--- a/tests/unit/metrics_tests.py
+++ b/tests/unit/metrics_tests.py
@@ -48,11 +48,14 @@ class RawTransportTests(unittest.TestCase):
     def test_sent_immediately(self, mock_make_socket):
         mocket = mock_make_socket.return_value
         transport = metrics.RawTransport(EXAMPLE_ENDPOINT)
+
+        self.assertEqual(mocket.connect.call_args,
+            mock.call(("127.0.0.1", 1234)))
+
         transport.send(b"metric")
 
-        self.assertEqual(mocket.sendto.call_count, 1)
-        self.assertEqual(mocket.sendto.call_args,
-            mock.call(b"metric", ("127.0.0.1", 1234)))
+        self.assertEqual(mocket.send.call_count, 1)
+        self.assertEqual(mocket.send.call_args, mock.call(b"metric"))
 
 
 class BufferedTransportTests(unittest.TestCase):
@@ -64,12 +67,12 @@ class BufferedTransportTests(unittest.TestCase):
         transport.send(b"a")
         transport.send(b"b")
         transport.send(b"c")
-        self.assertEqual(mocket.sendto.call_count, 0)
+        self.assertEqual(mocket.send.call_count, 0)
         transport.flush()
 
-        self.assertEqual(mocket.sendto.call_count, 1)
-        self.assertEqual(mocket.sendto.call_args,
-            mock.call(b"a\nb\nc", ("127.0.0.1", 1234)))
+        self.assertEqual(mocket.send.call_count, 1)
+        self.assertEqual(mocket.send.call_args,
+            mock.call(b"a\nb\nc"))
 
 
 class BaseClientTests(unittest.TestCase):


### PR DESCRIPTION
socket.sendto() was resolving the name of the statsd server each time we
needed to send a batch of metrics. This was obviously quite slow. By
doing an upfront socket.connect() call, the DNS lookup only happens
once.

Here's what it looked like when I put the IP address instead of hostname
in the configs:

![render 3](https://cloud.githubusercontent.com/assets/338853/11884367/3135026a-a4ce-11e5-973e-dac6a79a45f3.png)

:eyeglasses: @kjoconnor @bsimpson63 