### PR TITLE
Message queues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ virtualenv:
 before_install:
     - sudo add-apt-repository -y ppa:reddit/ppa
     - sudo apt-get update -q
-    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster
+    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc
 
 install:
     - pip install -e ".[gevent,pyramid]"

--- a/baseplate/crypto.py
+++ b/baseplate/crypto.py
@@ -19,7 +19,7 @@ if hasattr(hmac, "compare_digest"):
     # This was added in Python 2.7.7 and 3.3
     constant_time_compare = hmac.compare_digest
 else:
-    def constant_time_compare(val1, val2):
+    def constant_time_compare(actual, expected):
         """Return whether or not two strings match.
 
         The time taken is dependent on the number of characters provided
@@ -27,9 +27,12 @@ else:
         function resistant to timing attacks.
 
         """
-        result = len(val1) ^ len(val2)
-        for i in range(len(val1)):
-            result |= ord(val1[i]) ^ ord(val2[i % len(val2)])
+        actual_len = len(actual)
+        expected_len = len(expected)
+        result = actual_len ^ expected_len
+        if expected_len > 0:
+            for i in xrange(actual_len):
+                result |= ord(actual[i]) ^ ord(expected[i % expected_len])
         return result == 0
 
 

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -1,0 +1,124 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import select
+import time
+
+import posix_ipc
+
+
+class MessageQueueError(Exception):
+    """Base exception for message queue related errors."""
+    pass
+
+
+class TimedOutError(MessageQueueError):
+    """Raised when a message queue operation times out."""
+    def __init__(self):
+        super(TimedOutError, self).__init__(
+            "Timed out waiting for the message queue.")
+
+
+class _CumulativeTimeoutSelector(object):
+    """Helper to track a cumulative timeout across multiple select calls."""
+    def __init__(self, timeout):
+        self.time_remaining = timeout
+
+    def select(self, rfds=None, wfds=None):
+        if self.time_remaining is not None and self.time_remaining <= 0:
+            raise TimedOutError
+
+        # we use select.select here instead of the queue's own timeout ability
+        # so that if we're in gevent, the hub can monitor the queue's readiness
+        # rather than blocking the whole process.
+        start = time.time()
+        readable, writable, _ = select.select(
+            rfds or [], wfds or [], [], self.time_remaining)
+        elapsed = time.time() - start
+
+        if self.time_remaining > 0:
+            self.time_remaining -= elapsed
+
+        return readable, writable
+
+
+class MessageQueue(object):
+    """A gevent-friendly (but not required) inter process message queue.
+
+    ``name`` should be a string of up to 255 characters consisting of an
+    initial slash, followed by one or more characters, none of which are
+    slashes.
+
+    Note: This relies on POSIX message queues being available and
+    select(2)-able like other file descriptors. Not all operating systems
+    support this.
+
+    """
+    def __init__(self, name, max_messages, max_message_size):
+        self.queue = posix_ipc.MessageQueue(
+            name,
+            flags=posix_ipc.O_CREAT,
+            mode=0o0644,
+            max_messages=max_messages,
+            max_message_size=max_message_size,
+        )
+        self.queue.block = False
+
+    def get(self, timeout=None):
+        """Read a message from the queue.
+
+        :param float timeout: If the queue is empty, the call will block up to
+            ``timeout`` seconds or forever if ``None``.
+        :raises: :py:exc:`TimedOutError` The queue was empty for the allowed
+            duration of the call.
+
+        """
+        selector = _CumulativeTimeoutSelector(timeout)
+
+        while True:
+            try:
+                message, priority = self.queue.receive()
+                return message
+            except posix_ipc.SignalError:  # pragma: nocover
+                continue  # interrupted, just try again
+            except posix_ipc.BusyError:
+                selector.select(rfds=[self.queue.mqd])
+
+    def put(self, message, timeout=None):
+        """Add a message to the queue.
+
+        :param float timeout: If the queue is full, the call will block up to
+            ``timeout`` seconds or forever if ``None``.
+        :raises: :py:exc:`TimedOutError` The queue was full for the allowed
+            duration of the call.
+
+        """
+        selector = _CumulativeTimeoutSelector(timeout)
+
+        while True:
+            try:
+                return self.queue.send(message=message)
+            except posix_ipc.SignalError:  # pragma: nocover
+                continue  # interrupted, just try again
+            except posix_ipc.BusyError:
+                selector.select(wfds=[self.queue.mqd])
+
+    def unlink(self):
+        """Remove the queue from the system.
+
+        The queue will not leave until the last active user closes it.
+
+        """
+        self.queue.unlink()
+
+    def close(self):
+        """Close the queue, freeing related resources.
+
+        This must be called explicitly if queues are created/destroyed on the
+        fly. It is not automatically called when the object is reclaimed by
+        Python.
+
+        """
+        self.queue.close()

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper (>= 8),
                python-nose, python3-nose, python-mock,
                fbthrift-compiler,
                python-pyramid, python-fbthrift,
+               python-posix-ipc, python3-posix-ipc,
                python-sphinx | python3-sphinx, python-alabaster, python-sphinxcontrib.spelling
 Standards-Version: 3.9.5
 X-Python-Version: >= 2.7

--- a/docs/api/baseplate/message_queue.rst
+++ b/docs/api/baseplate/message_queue.rst
@@ -1,0 +1,29 @@
+baseplate.message_queue
+=======================
+
+.. automodule:: baseplate.message_queue
+
+.. note::
+
+   This implementation uses POSIX message queues and is not portable to
+   all operating systems.
+
+   There are also various limits on the sizes of queues:
+
+   * The ``msgqueue`` rlimit limits the amount of space the user can use on
+     message queues.
+   * The ``fs.mqueue.msg_max`` and ``fs.mqueue.msgsize_max`` sysctls limit the
+     maximum number of messages and the maximum size of each message respectively
+     which a queue can be configured to have.
+
+
+.. autoclass:: MessageQueue
+   :members:
+
+
+Exceptions
+----------
+
+.. autoexception:: MessageQueueError
+
+.. autoexception:: TimedOutError

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -15,5 +15,6 @@ Baseplate. It is organized alphabetically by module name.
    baseplate/crypto
    baseplate/diagnostics/index
    baseplate/integration/index
+   baseplate/message_queue
    baseplate/metrics
    baseplate/thrift_pool

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ PY3 = (sys.version_info.major == 3)
 
 install_requires = [
     "requests",
+    "posix_ipc",
 ],
 
 tests_require = [

--- a/tests/unit/crypto_tests.py
+++ b/tests/unit/crypto_tests.py
@@ -12,11 +12,15 @@ from .. import mock
 
 
 class ConstantTimeCompareTests(unittest.TestCase):
-    def check_equal(self):
+    def test_equal(self):
         self.assertTrue(crypto.constant_time_compare("abcdefg", "abcdefg"))
 
-    def check_inequal(self):
+    def test_inequal(self):
         self.assertFalse(crypto.constant_time_compare("abcdefg", "hijklmnop"))
+
+    def test_empty(self):
+        self.assertFalse(crypto.constant_time_compare("abcdefg", ""))
+        self.assertFalse(crypto.constant_time_compare("", "hijklmnop"))
 
 
 class SignatureTests(unittest.TestCase):


### PR DESCRIPTION
This will be helpful for communicating with sidekick processes on the same machine, e.g. events. I'm adding this here first and then moving the event collectors over to this from their SysV IPC queues. Once that's proven out, then the goal is to have r2 and baseplate app servers send messages to the collector via local-system queues and a small daemon, rather than going through Rabbit which is currently getting close to max throughput.

(this also includes a fix for a bug i introduced by trying to be too clever in constant_time_compare. i've made sure the code is identical to r2's copy again. i should've known better, sorry)

:eyeglasses: @bsimpson63 @ketralnis @MelissaCole 