### PR TITLE
Add a system for sending events to the event collector

### DIFF
--- a/baseplate/_compat.py
+++ b/baseplate/_compat.py
@@ -11,12 +11,15 @@ import sys
 if sys.version_info.major == 3:  # pragma: nocover
     import configparser
     import queue
+    from io import BytesIO
 else:  # pragma: nocover
     import ConfigParser as configparser
     import Queue as queue
+    from cStringIO import StringIO as BytesIO
 
 
 __all__ = [
     "configparser",
     "queue",
+    "BytesIO",
 ]

--- a/baseplate/events/__init__.py
+++ b/baseplate/events/__init__.py
@@ -1,0 +1,23 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+#from __future__ import unicode_literals This breaks __all__ on PY2
+
+MAX_EVENT_SIZE=102400
+MAX_QUEUE_SIZE=10000
+
+from .queue import (
+    Event,
+    EventError,
+    EventQueue,
+    EventQueueFullError,
+    EventTooLargeError,
+)
+
+__all__ = [
+    "Event",
+    "EventError",
+    "EventQueue",
+    "EventQueueFullError",
+    "EventTooLargeError",
+]

--- a/baseplate/events/publisher.py
+++ b/baseplate/events/publisher.py
@@ -1,0 +1,203 @@
+import argparse
+import email.utils
+import gzip
+import hashlib
+import hmac
+import logging
+import time
+
+import requests
+
+from . import MAX_EVENT_SIZE, MAX_QUEUE_SIZE
+from .. import config, make_metrics_client
+from .. _compat import configparser, BytesIO
+from .. message_queue import MessageQueue, TimedOutError
+
+
+logger = logging.getLogger(__name__)
+
+
+# seconds to wait for the event collector
+POST_TIMEOUT = 3
+# maximum time (seconds) an event can sit around while we wait for more
+# messages to batch
+MAX_BATCH_AGE = 1
+# seconds to wait between retries when the collector fails
+RETRY_DELAY = 2
+
+
+class Batcher(object):
+    """Time-aware batching producer.
+
+    A batch-consumer gives necessary context to this object. It must provide:
+        * batch_size_limit - the maximum size of an individual batch
+        * batch_size_overhead - base size cost of a batch
+        * get_item_size() - given an item, return its batch-relevant size
+        * consume_batch() - consume a fully formed batch
+
+    A flush may occur if the batch reaches the maximum specified size during
+    add() or if explicitly flush()ed.
+
+    """
+    def __init__(self, consumer):
+        self.consumer = consumer
+        self.batch = []
+        self.batch_size = self.consumer.batch_size_overhead
+        self.batch_start = None
+
+    @property
+    def batch_age(self):
+        """Return the age in seconds of the oldest item in the batch.
+
+        If there are no items in the batch, 0 is returned.
+
+        """
+        if not self.batch_start:
+            return 0
+        return time.time() - self.batch_start
+
+    def add(self, item):
+        """Add an item to the batch, potentially flushing."""
+        item_size = self.consumer.get_item_size(item)
+        if self.batch_size + item_size > self.consumer.batch_size_limit:
+            self.flush()
+        self.batch.append(item)
+        self.batch_size += item_size
+        if not self.batch_start:
+            self.batch_start = time.time()
+
+    def flush(self):
+        """Explicitly flush the batch if any items are enqueued."""
+        if self.batch:
+            self.consumer.consume_batch(self.batch)
+            self.batch = []
+            self.batch_size = self.consumer.batch_size_overhead
+            self.batch_start = None
+
+
+def gzip_compress(content):
+    buf = BytesIO()
+    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9) as f:
+        f.write(content)
+    return buf.getvalue()
+
+
+class BatchConsumer(object):
+    batch_size_overhead = 2  # the [] that wrap the json list
+    batch_size_limit = 500 * 1024
+
+    def __init__(self, metrics_client, cfg):
+        self.metrics = metrics_client
+        self.url = "https://%s/v1" % cfg.collector.hostname
+        self.key_name = cfg.key.name
+        self.key_secret = cfg.key.secret
+        self.session = requests.Session()
+
+    @staticmethod
+    def get_item_size(item):
+        # the item is already serialized, so we'll just add one byte for comma
+        return len(item) + 1
+
+    def _sign_payload(self, payload):
+        digest = hmac.new(self.key_secret, payload, hashlib.sha256).hexdigest()
+        return "key={key}, mac={mac}".format(key=self.key_name, mac=digest)
+
+    def consume_batch(self, items):
+        logger.info("sending batch of %d items", len(items))
+        payload = b"[" + b",".join(items) + b"]"
+        compressed_payload = gzip_compress(payload)
+        headers = {
+            "Date": email.utils.formatdate(usegmt=True),
+            "User-Agent": "baseplate-event-publisher/1.0",
+            "Content-Type": "application/json",
+            "X-Signature": self._sign_payload(payload),
+            "Content-Encoding": "gzip",
+        }
+
+        while True:
+            try:
+                with self.metrics.timer("post"):
+                    response = self.session.post(
+                        self.url,
+                        headers=headers,
+                        data=compressed_payload,
+                        timeout=POST_TIMEOUT,
+
+                        # http://docs.python-requests.org/en/latest/user/advanced/#keep-alive
+                        stream=False,
+                    )
+                response.raise_for_status()
+            except requests.HTTPError as exc:
+                self.metrics.counter("error.http").increment()
+                logger.exception("HTTP Request failed")
+
+                # we should crash if it's our fault
+                if getattr(exc, "response", None) and exc.response.status_code < 500:
+                    raise
+            except IOError:
+                self.metrics.counter("error.io").increment()
+                logger.exception("HTTP Request failed")
+            else:
+                self.metrics.counter("sent").increment(len(items))
+                return
+
+            time.sleep(RETRY_DELAY)
+
+
+def publish_events():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("config_file", type=argparse.FileType("r"),
+        help="path to a configuration file")
+    arg_parser.add_argument("--queue-name", default="main",
+        help="name of event queue / publisher config (default: main)")
+    arg_parser.add_argument("--debug", default=False, action="store_true",
+        help="enable debug logging")
+    args = arg_parser.parse_args()
+
+    if args.debug:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level)
+
+    config_parser = configparser.ConfigParser()
+    config_parser.readfp(args.config_file)
+    raw_config = dict(config_parser.items("event-publisher:" + args.queue_name))
+    cfg = config.parse_config(raw_config, {
+        "collector": {
+            "hostname": config.String,
+        },
+
+        "key": {
+            "name": config.String,
+            "secret": config.Base64,
+        },
+    })
+
+    metrics_client = make_metrics_client(raw_config)
+
+    consumer = BatchConsumer(metrics_client, cfg)
+    batcher = Batcher(consumer)
+    event_queue = MessageQueue(
+        "/events-" + args.queue_name,
+        max_messages=MAX_QUEUE_SIZE,
+        max_message_size=MAX_EVENT_SIZE,
+    )
+
+    try:
+        while True:
+            try:
+                message = event_queue.get(timeout=.2)
+            except TimedOutError:
+                pass
+            else:
+                batcher.add(message)
+
+            if batcher.batch_age > MAX_BATCH_AGE:
+                batcher.flush()
+    finally:
+        batcher.flush()
+
+
+if __name__ == "__main__":
+    publish_events()

--- a/baseplate/events/queue.py
+++ b/baseplate/events/queue.py
@@ -1,0 +1,139 @@
+"""Client library for sending events to the data processing system.
+
+This is for use with the event collector system. Events generally track
+something that happens in production that we want to instrument for planning
+and analytical purposes.
+
+Events are serialized and put onto a message queue on the same server. These
+serialized events are then consumed and published to the remote event collector
+by a separate daemon.
+
+See also: https://github.com/reddit/event-collector
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import calendar
+import json
+import time
+import uuid
+
+from . import MAX_EVENT_SIZE, MAX_QUEUE_SIZE
+from baseplate.message_queue import MessageQueue, TimedOutError
+
+
+class Event(object):
+    """An event."""
+    def __init__(self, topic, event_type, timestamp=None, id=None):
+        self.topic = topic
+        self.event_type = event_type
+        if timestamp:
+            if timestamp.tzinfo and timestamp.utcoffset().total_seconds() != 0:
+                raise ValueError("Timestamps must be in UTC")
+            self.timestamp = calendar.timegm(timestamp.timetuple()) * 1000
+        else:
+            self.timestamp = time.time() * 1000
+        self.id = id or uuid.uuid4()
+        self.payload = {}
+
+    def get_field(self, key, obfuscated=False):
+        """Get the value of a field in the event.
+
+        If the field is not present, :py:data:`None` is returned.
+
+        :param str key: The name of the field.
+        :param bool obfuscated: Whether to look for the field in the obfuscated
+            payload.
+
+        """
+
+        if not obfuscated:
+            payload = self.payload
+        else:
+            payload = self.payload.get("obfuscated_data", {})
+        return payload.get(key, None)
+
+    def set_field(self, key, value, obfuscate=False):
+        """Set the value for a field in the event.
+
+        :param str key: The name of the field.
+        :param value: The value to set the field to. Should be JSON
+            serializable.
+        :param bool obfuscate: Whether or not to put the field in the obfuscated
+            section. This is used for sensitive info like IP addresses that must
+            be treated with care.
+
+        """
+        if not obfuscate:
+            self.payload[key] = value
+        else:
+            obfuscated_payload = self.payload.setdefault("obfuscated_data", {})
+            obfuscated_payload[key] = value
+
+    def serialize(self):
+        return json.dumps({
+            "event_topic": self.topic,
+            "event_type": self.event_type,
+            "event_ts": self.timestamp,
+            "uuid": str(self.id),
+            "payload": self.payload,
+        })
+
+
+class EventError(Exception):
+    """Base class for event related exceptions."""
+    pass
+
+
+class EventTooLargeError(EventError):
+    """Raised when a serialized event is too large to send."""
+    def __init__(self, size):
+        super(EventTooLargeError, self).__init__(
+            "Event is too large to send (%d bytes)" % size)
+
+
+class EventQueueFullError(EventError):
+    """Raised when the queue of events is full.
+
+    This usually indicates that the event publisher is having trouble talking
+    to the event collector.
+
+    """
+    def __init__(self):
+        super(EventQueueFullError, self).__init__("The event queue is full.")
+
+
+class EventQueue(object):
+    """A queue to transfer events to the publisher."""
+
+    def __init__(self, name):
+        self.queue = MessageQueue(
+            "/events-" + name,
+            max_messages=MAX_QUEUE_SIZE,
+            max_message_size=MAX_EVENT_SIZE,
+        )
+
+    def put(self, event):
+        """Add an event to the queue.
+
+        The queue is local to the server this code is run on. The event
+        publisher on the server will take these events and send them to the
+        collector.
+
+        :param baseplate.events.Event event: The event to send.
+        :raises: :py:exc:`EventTooLargeError` The serialized event is too large.
+        :raises: :py:exc:`EventQueueFullError` The queue is full. Events are
+            not being published fast enough.
+
+        """
+        serialized = event.serialize()
+        if len(serialized) > MAX_EVENT_SIZE:
+            raise EventTooLargeError(len(serialized))
+
+        try:
+            self.queue.put(serialized, timeout=0)
+        except TimedOutError:
+            raise EventQueueFullError

--- a/baseplate/events/queue.py
+++ b/baseplate/events/queue.py
@@ -84,7 +84,7 @@ class Event(object):
         return json.dumps({
             "event_topic": self.topic,
             "event_type": self.event_type,
-            "event_ts": self.timestamp,
+            "event_ts": int(self.timestamp),
             "uuid": str(self.id),
             "payload": self.payload,
         })

--- a/baseplate/events/queue.py
+++ b/baseplate/events/queue.py
@@ -67,6 +67,13 @@ class Event(object):
             be treated with care.
 
         """
+
+        # There's no need to send null/empty values, the collector will act
+        # the same whether they're sent or not. Zeros are important though,
+        # so we can't use a simple boolean truth check here.
+        if value is None or value == "":
+            return
+
         if not obfuscate:
             self.payload[key] = value
         else:

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -38,7 +38,7 @@ class _CumulativeTimeoutSelector(object):
             rfds or [], wfds or [], [], self.time_remaining)
         elapsed = time.time() - start
 
-        if self.time_remaining > 0:
+        if self.time_remaining is not None and self.time_remaining > 0:
             self.time_remaining -= elapsed
 
         return readable, writable

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -1,3 +1,21 @@
+"""A gevent-friendly POSIX message queue.
+
+These message queues store messages in the kernel, allow multiple processes to
+read and/or write, and persist even if the processes are all gone. The messages
+do not persist through reboots and are not accessible off the local machine.
+
+This module can also be run as a command-line tool to consume, log, and discard
+messages from a given queue::
+
+    python -m baseplate.message_queue --read /queue
+
+or to write arbitrary messages to the queue::
+
+    echo hello! | python -m baseplate.message_queue --write /queue
+
+See ``--help`` for more info.
+
+"""
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
@@ -122,3 +140,38 @@ class MessageQueue(object):
 
         """
         self.queue.close()
+
+
+def queue_tool():
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--max-messages", type=int, default=10,
+        help="if creating the queue, what to set the maximum queue length to")
+    parser.add_argument("--max-message-size", type=int, default=8096,
+        help="if creating the queue, what to set the maximum message size to")
+    parser.add_argument("queue_name", help="the name of the queue to consume")
+
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--read", action="store_const", dest="mode", const="read",
+        help="read, log, and discard messages from the named queue")
+    group.add_argument("--write", action="store_const", dest="mode", const="write",
+        help="read messages from stdin and write them to the named queue")
+
+    args = parser.parse_args()
+
+    queue = MessageQueue(args.queue_name, args.max_messages, args.max_message_size)
+
+    if args.mode == "read":
+        while True:
+            item = queue.get()
+            print(item)
+    else:
+        for line in sys.stdin:
+            queue.put(line.rstrip("\n"))
+
+
+if __name__ == "__main__":
+    queue_tool()

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -155,6 +155,8 @@ def queue_tool():
     parser.add_argument("queue_name", help="the name of the queue to consume")
 
     group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--create", action="store_const", dest="mode", const="create",
+        help="create the named queue if it doesn't exist and exit")
     group.add_argument("--read", action="store_const", dest="mode", const="read",
         help="read, log, and discard messages from the named queue")
     group.add_argument("--write", action="store_const", dest="mode", const="write",
@@ -168,7 +170,7 @@ def queue_tool():
         while True:
             item = queue.get()
             print(item)
-    else:
+    elif args.mode == "write":
         for line in sys.stdin:
             queue.put(line.rstrip("\n"))
 

--- a/docs/api/baseplate/events.rst
+++ b/docs/api/baseplate/events.rst
@@ -1,0 +1,51 @@
+baseplate.events
+================
+
+.. automodule:: baseplate.events
+
+Building Events
+---------------
+
+.. autoclass:: Event
+   :members:
+
+
+Queing Events
+-------------
+
+.. autoclass:: EventQueue
+   :members:
+
+
+Exceptions
+~~~~~~~~~~
+
+.. autoexception:: EventError
+
+.. autoexception:: EventTooLargeError
+
+.. autoexception:: EventQueueFullError
+
+
+Publishing Events
+-----------------
+
+Events that are put onto an :py:class:`EventQueue` are consumed by a separate
+process and published to the remote event collector service. The publisher is
+in baseplate and can be run as follows::
+
+    python -m baseplate.events.publisher --queue-name something config_file.ini
+
+The publisher will look at the specified INI file to find its configuration.
+Given a queue name of ``something`` (as in the example above), it will expect a
+section in the INI file called ``[event-publisher:something]`` with content
+like below::
+
+   [event-publisher:something]
+   collector.hostname = some-domain.example.com
+
+   key.name = NameOfASecretKey
+   key.secret = Base64-encoded-blob-of-randomness
+
+   metrics.namespace = a.name.to.put.metrics.under
+   metrics.endpoint = the-statsd-host:1234

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -14,6 +14,7 @@ Baseplate. It is organized alphabetically by module name.
    baseplate/core
    baseplate/crypto
    baseplate/diagnostics/index
+   baseplate/events
    baseplate/integration/index
    baseplate/message_queue
    baseplate/metrics

--- a/tests/unit/events/publisher_tests.py
+++ b/tests/unit/events/publisher_tests.py
@@ -61,10 +61,10 @@ class BatcherTests(unittest.TestCase):
 
 class CompressTests(unittest.TestCase):
     def test_compress(self):
-        input = b"test"
-        compressed = publisher.gzip_compress(input)
-        uncompressed = gzip.GzipFile(fileobj=BytesIO(compressed)).read()
-        self.assertEqual(input, uncompressed)
+        raw = b"test"
+        compressed = publisher.gzip_compress(raw)
+        decompressed = gzip.GzipFile(fileobj=BytesIO(compressed)).read()
+        self.assertEqual(raw, decompressed)
 
 
 class ConsumerTests(unittest.TestCase):

--- a/tests/unit/events/publisher_tests.py
+++ b/tests/unit/events/publisher_tests.py
@@ -3,7 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import datetime
 import gzip
 import unittest
 

--- a/tests/unit/events/publisher_tests.py
+++ b/tests/unit/events/publisher_tests.py
@@ -1,0 +1,112 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import gzip
+import unittest
+
+import requests
+
+from baseplate import config, metrics
+from baseplate._compat import BytesIO
+from baseplate.events import publisher
+
+from ... import mock
+
+
+class BatcherTests(unittest.TestCase):
+    def setUp(self):
+        self.consumer = mock.Mock()
+        self.consumer.batch_size_overhead = 0
+        self.consumer.get_item_size = lambda item: len(item)
+        self.consumer.batch_size_limit = 5
+        self.batcher = publisher.Batcher(self.consumer)
+
+    def test_flush_empty_does_nothing(self):
+        self.batcher.flush()
+        self.assertEqual(self.consumer.consume_batch.called, False)
+
+    def test_start_time(self):
+        with mock.patch("time.time") as mock_time:
+            self.assertEqual(self.batcher.batch_age, 0)
+
+            mock_time.return_value = 33
+            self.batcher.add("a")
+            self.assertEqual(self.batcher.batch_start, 33)
+
+            mock_time.return_value = 34
+            self.batcher.add("b")
+            self.assertEqual(self.batcher.batch_start, 33)
+
+            mock_time.return_value = 35
+            self.assertEqual(self.batcher.batch_age, 2)
+
+        self.batcher.flush()
+        self.assertEqual(self.batcher.batch_start, None)
+
+    def test_manual_flush(self):
+        self.batcher.add("a")
+        self.batcher.add("b")
+        self.batcher.flush()
+        self.consumer.consume_batch.assert_called_once_with(["a", "b"])
+
+    def test_flush_when_full(self):
+        for i in range(7):
+            self.batcher.add(str(i))
+        self.consumer.consume_batch.assert_called_once_with(
+            ["0", "1", "2", "3", "4"])
+
+
+class CompressTests(unittest.TestCase):
+    def test_compress(self):
+        input = b"test"
+        compressed = publisher.gzip_compress(input)
+        uncompressed = gzip.GzipFile(fileobj=BytesIO(compressed)).read()
+        self.assertEqual(input, uncompressed)
+
+
+class ConsumerTests(unittest.TestCase):
+    @mock.patch("requests.Session", autospec=True)
+    def setUp(self, Session):
+        self.config = config.ConfigNamespace()
+        self.config.collector = config.ConfigNamespace()
+        self.config.collector.hostname = "test.local"
+        self.config.key = config.ConfigNamespace()
+        self.config.key.name = "TestKey"
+        self.config.key.secret = b"hunter2"
+
+        self.session = Session.return_value
+
+        self.metrics_client = mock.MagicMock(autospec=metrics.Client)
+
+        self.consumer = publisher.BatchConsumer(
+            self.metrics_client, self.config)
+
+    def test_item_size(self):
+        size = self.consumer.get_item_size(b"{}")
+        self.assertEqual(size, 3)
+
+    def test_publish_success(self):
+        events = [b'{"example": "value"}']
+
+        self.consumer.consume_batch(events)
+
+        self.assertEqual(self.session.post.call_count, 1)
+
+        args, kwargs = self.session.post.call_args
+        headers = kwargs.get("headers", {})
+        self.assertEqual(args[0], "https://test.local/v1")
+        self.assertEqual(headers["Content-Type"], "application/json")
+        self.assertEqual(headers["X-Signature"], "key=TestKey, mac=7c46d56b99cd4cb05e08238c1d4c10a2f330795e9d7327f17cc66fd206bf1179")
+
+    @mock.patch("time.sleep")
+    def test_publish_retry(self, mock_sleep):
+        self.session.post.side_effect = [requests.HTTPError(504), IOError, mock.Mock()]
+        events = [b'{"example": "value"}']
+
+        self.consumer.consume_batch(events)
+
+        self.assertEqual(mock_sleep.call_count, 2)
+        self.assertEqual(self.session.post.call_count, 3)

--- a/tests/unit/events/publisher_tests.py
+++ b/tests/unit/events/publisher_tests.py
@@ -53,7 +53,7 @@ class BatcherTests(unittest.TestCase):
         self.consumer.consume_batch.assert_called_once_with(["a", "b"])
 
     def test_flush_when_full(self):
-        for i in range(7):
+        for i in range(self.consumer.batch_size_limit+1):
             self.batcher.add(str(i))
         self.consumer.consume_batch.assert_called_once_with(
             ["0", "1", "2", "3", "4"])

--- a/tests/unit/events/queue_tests.py
+++ b/tests/unit/events/queue_tests.py
@@ -1,0 +1,99 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import json
+import unittest
+
+from baseplate.events import (
+    Event,
+    EventError,
+    EventQueue,
+    EventQueueFullError,
+    EventTooLargeError,
+    MAX_EVENT_SIZE,
+)
+from baseplate.message_queue import MessageQueue, TimedOutError
+
+from ... import mock
+
+
+class EventTests(unittest.TestCase):
+    @mock.patch("uuid.uuid4")
+    @mock.patch("time.time")
+    def test_minimal_constructor(self, time, uuid):
+        time.return_value = 333
+        uuid.return_value = "1-2-3-4"
+
+        event = Event("topic", "type")
+
+        self.assertEqual(event.topic, "topic")
+        self.assertEqual(event.event_type, "type")
+        self.assertEqual(event.timestamp, 333000)
+        self.assertEqual(event.id, "1-2-3-4")
+
+    def test_timestamp_specified(self):
+        timestamp = datetime.datetime(2016, 2, 23, 0, 3, 17)
+        event = Event("topic", "type", timestamp=timestamp)
+        self.assertEqual(event.timestamp, 1456185797000)
+
+    @mock.patch("uuid.uuid4")
+    @mock.patch("time.time")
+    def test_serialize(self, time, uuid):
+        time.return_value = 333
+        uuid.return_value = "1-2-3-4"
+
+        event = Event("topic", "type")
+        event.set_field("normal", "value1")
+        event.set_field("obfuscated", "value2", obfuscate=True)
+
+        serialized = event.serialize()
+        deserialized = json.loads(serialized)
+
+        self.assertEqual(deserialized, {
+            "event_topic": "topic",
+            "event_type": "type",
+            "event_ts": 333000,
+            "uuid": "1-2-3-4",
+            "payload": {
+                "normal": "value1",
+                "obfuscated_data": {
+                    "obfuscated": "value2",
+                },
+            },
+        })
+
+
+class EventQueueTests(unittest.TestCase):
+    @mock.patch("baseplate.events.queue.MessageQueue", autospec=MessageQueue)
+    def setUp(self, MessageQueue):
+        self.message_queue = MessageQueue.return_value
+        self.queue = EventQueue("test")
+
+    def test_send_event(self):
+        mock_event = mock.Mock(autospec=Event)
+        mock_event.serialize.return_value = "i_am_serialized"
+
+        self.queue.put(mock_event)
+
+        self.assertEqual(self.message_queue.put.call_count, 1)
+        args, kwargs = self.message_queue.put.call_args
+        self.assertEqual(args[0], mock_event.serialize.return_value)
+
+    def test_event_too_large(self):
+        mock_event = mock.Mock(autospec=Event)
+        mock_event.serialize.return_value = "x" * (MAX_EVENT_SIZE+1)
+
+        with self.assertRaises(EventTooLargeError):
+            self.queue.put(mock_event)
+
+    def test_event_queue_full(self):
+        mock_event = mock.Mock(autospec=Event)
+        mock_event.serialize.return_value = ""
+
+        self.message_queue.put.side_effect = TimedOutError
+
+        with self.assertRaises(EventQueueFullError):
+            self.queue.put(mock_event)

--- a/tests/unit/events/queue_tests.py
+++ b/tests/unit/events/queue_tests.py
@@ -48,6 +48,8 @@ class EventTests(unittest.TestCase):
         event = Event("topic", "type")
         event.set_field("normal", "value1")
         event.set_field("obfuscated", "value2", obfuscate=True)
+        event.set_field("empty", "")
+        event.set_field("null", None)
 
         serialized = event.serialize()
         deserialized = json.loads(serialized)

--- a/tests/unit/events/queue_tests.py
+++ b/tests/unit/events/queue_tests.py
@@ -20,6 +20,11 @@ from baseplate.message_queue import MessageQueue, TimedOutError
 from ... import mock
 
 
+class MockTZ(datetime.tzinfo):
+    def utcoffset(self, dt):
+        return datetime.timedelta(hours=2)
+
+
 class EventTests(unittest.TestCase):
     @mock.patch("uuid.uuid4")
     @mock.patch("time.time")
@@ -38,6 +43,11 @@ class EventTests(unittest.TestCase):
         timestamp = datetime.datetime(2016, 2, 23, 0, 3, 17)
         event = Event("topic", "type", timestamp=timestamp)
         self.assertEqual(event.timestamp, 1456185797000)
+
+    def test_timestamp_not_utc(self):
+        timestamp = datetime.datetime(2016, 2, 23, 0, 3, 17, tzinfo=MockTZ())
+        with self.assertRaises(ValueError):
+            Event("topic", "type", timestamp=timestamp)
 
     @mock.patch("uuid.uuid4")
     @mock.patch("time.time")


### PR DESCRIPTION
This is split into two parts: a system for building and queing events,
and a daemon which reads from a queue, batches, and publishes events to
the collector. The goal is to make it so we can send a _lot_ of events
without overwhelming a central server like Rabbit.

It is immediately useful for @MelissaCole's clicktracker service, but I'm also
planning on getting r2 cut over to this ASAP so we can continue adding more
instrumentation and A/B testing without worrying about overwhelming the Rabbit
box.

:eyeglasses: @MelissaCole @umbrae @KeyserSosa 

cc: @Kaitaan @jophuds 