### PR TITLE
MessageSigner: Return some info about valid signatures

### DIFF
--- a/docs/api/baseplate/crypto.rst
+++ b/docs/api/baseplate/crypto.rst
@@ -9,6 +9,8 @@ Message Signing
 .. autoclass:: MessageSigner
    :members:
 
+.. autoclass:: SignatureInfo
+
 Exceptions
 ~~~~~~~~~~
 

--- a/tests/unit/crypto_tests.py
+++ b/tests/unit/crypto_tests.py
@@ -34,6 +34,17 @@ class SignatureTests(unittest.TestCase):
         self.signer.validate_signature(self.message, signature)
 
     @mock.patch("time.time")
+    def test_signature_info(self, time):
+        time.return_value = 0
+        signature = self.signer.make_signature(self.message, max_age=datetime.timedelta(seconds=30))
+
+        time.return_value = 10
+        info = self.signer.validate_signature(self.message, signature)
+
+        self.assertEqual(info.version, 1)
+        self.assertEqual(info.expiration, 30)
+
+    @mock.patch("time.time")
     def test_expired(self, time):
         time.return_value = 0
         signature = self.signer.make_signature(self.message, max_age=datetime.timedelta(seconds=30))

--- a/tests/unit/crypto_tests.py
+++ b/tests/unit/crypto_tests.py
@@ -38,7 +38,6 @@ class SignatureTests(unittest.TestCase):
         time.return_value = 0
         signature = self.signer.make_signature(self.message, max_age=datetime.timedelta(seconds=30))
 
-        time.return_value = 10
         info = self.signer.validate_signature(self.message, signature)
 
         self.assertEqual(info.version, 1)


### PR DESCRIPTION
This is useful if we want to collect metrics on how old signatures are
when they are used, even if valid.

:eyeglasses: @MelissaCole @umbrae 

cc: WEB-1622