### PR TITLE
Pass exception information to span observers when spans end

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -37,8 +37,13 @@ class SpanObserver(object):  # pragma: nocover
         """Called when an annotation is added to the observed span."""
         pass
 
-    def on_stop(self):
-        """Called when the observed span is stopped."""
+    def on_stop(self, error):
+        """Called when the observed span is stopped.
+
+        :param error: If the span ended because of an exception, the instance
+            raised. Otherwise, :py:data:`None`.
+
+        """
         pass
 
 
@@ -180,17 +185,23 @@ class Span(object):
         for observer in self.observers:
             observer.on_annotate(key, value)
 
-    def stop(self):
-        """Record the end of the span."""
+    def stop(self, error=None):
+        """Record the end of the span.
+
+        :param error: If the span ended because of an exception, this should
+            be that exception. The default is :py:data:`None` which indicates
+            normal exit.
+
+        """
         for observer in self.observers:
-            observer.on_stop()
+            observer.on_stop(error=error)
 
     def __enter__(self):
         self.start()
         return self
 
     def __exit__(self, exc_type, value, traceback):
-        self.stop()
+        self.stop(error=value)
 
 
 class RootSpan(Span):

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -41,7 +41,7 @@ class MetricsSpanObserver(SpanObserver):
     def on_annotate(self, key, value):  # pragma: nocover
         pass
 
-    def on_stop(self):
+    def on_stop(self, error):
         self.timer.stop()
 
 
@@ -49,6 +49,6 @@ class MetricsRootSpanObserver(MetricsSpanObserver):
     def on_child_span_created(self, span):  # pragma: nocover
         return MetricsSpanObserver(self.batch, "clients." + span.name)
 
-    def on_stop(self):
-        super(MetricsRootSpanObserver, self).on_stop()
+    def on_stop(self, error):
+        super(MetricsRootSpanObserver, self).on_stop(error)
         self.batch.flush()

--- a/tests/unit/diagnostics/metrics_tests.py
+++ b/tests/unit/diagnostics/metrics_tests.py
@@ -42,7 +42,7 @@ class RootSpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop()
+        observer.on_stop(error=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
         self.assertEqual(mock_batch.flush.call_count, 1)
 
@@ -59,5 +59,5 @@ class SpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop()
+        observer.on_stop(error=None)
         self.assertEqual(mock_timer.stop.call_count, 1)


### PR DESCRIPTION
This allows us to take different actions depending on if the span exited
cleanly or exceptionally, such as automatically sending a "this request
failed" metric or the like.

Note: this is an API-breaking change. r2 is currently the only
subclasser of Span outside of baseplate, so that should be safe to fix
up before rolling this out.

This is in aid of #19 

:eyeglasses: @dellis23 @bsimpson63 