### PR TITLE
Pull Einhorn client code into separate module

### DIFF
--- a/baseplate/server/einhorn.py
+++ b/baseplate/server/einhorn.py
@@ -1,0 +1,75 @@
+"""Client library for children of Einhorn."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import contextlib
+import json
+import os
+import socket
+
+
+class NotEinhornWorker(Exception):
+    pass
+
+
+def is_worker():
+    """Return if this process is an Einhorn worker."""
+    return os.getppid() == int(os.environ.get("EINHORN_MASTER_PID", -1))
+
+
+def get_socket_count():
+    """Return how many sockets are bound."""
+    if not is_worker():
+        raise NotEinhornWorker
+
+    return int(os.environ.get("EINHORN_FD_COUNT", 0))
+
+
+def get_socket(index=0):
+    """Get an Einhorn-bound socket from the environment.
+
+    Einhorn can bind multiple sockets (via multiple -b arguments), the
+    ``index`` parameter can be used to choose which socket to retrieve.  When
+    sockets are bound, Einhorn provides several environment variables to child
+    worker processes:
+
+    - EINHORN_FD_COUNT: the number of sockets bound
+    - EINHORN_FD_#: for each socket bound, the file descriptor for that socket
+    - EINHORN_FD_FAMILY_#: for each socket bound, the protocol family of that
+        socket (this is a recent addition, so if it's not present default to
+        AF_INET)
+
+    :param int index: The socket number to get.
+    :rtype: :py:class:`socket.socket`
+
+    """
+    if not is_worker():
+        raise NotEinhornWorker
+
+    fd_count = get_socket_count()
+    if not (0 <= index < fd_count):
+        raise IndexError
+
+    fileno = int(os.environ["EINHORN_FD_%d" % index])
+    family_name = os.environ.get("EINHORN_FD_FAMILY_%d" % index, "AF_INET")
+    assert family_name.startswith("AF_"), "invalid socket family name"
+    family = getattr(socket, family_name)
+    return socket.fromfd(fileno, family, socket.SOCK_STREAM)
+
+
+def ack_startup():
+    """Send acknowledgement that we started up to the Einhorn master."""
+    if not is_worker():
+        raise NotEinhornWorker
+
+    control_sock_name = os.environ["EINHORN_SOCK_PATH"]
+    control_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    control_sock.connect(control_sock_name)
+
+    with contextlib.closing(control_sock):
+        control_sock.sendall((json.dumps({
+            "command": "worker:ack",
+            "pid": os.getpid(),
+        }) + "\n").encode("utf-8"))

--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -94,7 +94,7 @@ its command socket.
 
 An example command line::
 
-   einhorn -g -m manual -n 4 --bind localhost:9190 \
+   einhorn -m manual -n 4 --bind localhost:9190 \
       baseplate-serve2 myapp.ini
 
 .. _Stripe's Einhorn socket manager: https://github.com/stripe/einhorn

--- a/tests/unit/server/einhorn_tests.py
+++ b/tests/unit/server/einhorn_tests.py
@@ -1,0 +1,83 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import socket
+import unittest
+
+from baseplate.server import einhorn
+
+from ... import mock
+
+
+class NotEinhornWorkerTests(unittest.TestCase):
+    def test_is_not_worker(self):
+        self.assertFalse(einhorn.is_worker())
+
+    def test_get_socket_count(self):
+        with self.assertRaises(einhorn.NotEinhornWorker):
+            einhorn.get_socket_count()
+
+    def test_get_socket(self):
+        with self.assertRaises(einhorn.NotEinhornWorker):
+            einhorn.get_socket()
+
+    def test_send_ack(self):
+        with self.assertRaises(einhorn.NotEinhornWorker):
+            einhorn.ack_startup()
+
+
+@mock.patch.dict("os.environ", {
+    "EINHORN_MASTER_PID": "123",
+    "EINHORN_SOCK_PATH": "/tmp/einhorn.sock",
+    "EINHORN_FD_COUNT": "2",
+    "EINHORN_FD_0": "5",
+    "EINHORN_FD_1": "6",
+    "EINHORN_FD_FAMILY_1": "AF_UNIX",
+}, clear=True)
+class EinhornWorkerTests(unittest.TestCase):
+    def setUp(self):
+        getppid_patcher = mock.patch("os.getppid")
+        getppid = getppid_patcher.start()
+        getppid.return_value = 123
+        self.addCleanup(getppid_patcher.stop)
+
+    def test_is_worker(self):
+        self.assertTrue(einhorn.is_worker())
+
+    def test_get_socket_count(self):
+        self.assertEqual(einhorn.get_socket_count(), 2)
+
+    @mock.patch("socket.fromfd", autospec=True)
+    def test_get_socket(self, fromfd):
+        sock = einhorn.get_socket()
+        fromfd.assert_called_with(5, socket.AF_INET, socket.SOCK_STREAM)
+        self.assertEqual(sock, fromfd.return_value)
+
+    @mock.patch("socket.fromfd", autospec=True)
+    def test_get_socket_unix(self, fromfd):
+        sock = einhorn.get_socket(1)
+        fromfd.assert_called_with(6, socket.AF_UNIX, socket.SOCK_STREAM)
+        self.assertEqual(sock, fromfd.return_value)
+
+    def test_get_socket_out_of_bounds(self):
+        with self.assertRaises(IndexError):
+            einhorn.get_socket(-1)
+
+        with self.assertRaises(IndexError):
+            einhorn.get_socket(2)
+
+    @mock.patch("socket.socket")
+    @mock.patch("os.getpid", autospec=True)
+    def test_send_ack(self, getpid, sock):
+        getpid.return_value = 1337
+
+        einhorn.ack_startup()
+
+        sock.assert_called_with(socket.AF_UNIX, socket.SOCK_STREAM)
+        mocket = sock.return_value
+        mocket.connect.assert_called_with("/tmp/einhorn.sock")
+
+        self.assertEqual(mocket.sendall.call_count, 1)
+        self.assertEqual(mocket.close.call_count, 1)


### PR DESCRIPTION
This makes a more clearly defined interface for interacting with Einhorn
and is a little more robust with respect to detecting if we're a child
of Einhorn.

:eyeglasses: @dellis23 @ckwang8128 