### PR TITLE
Retries!

### DIFF
--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -3,10 +3,14 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import contextlib
 import functools
 import inspect
 
+from thrift.transport.TTransport import TTransportException
+
 from . import ContextFactory
+from ..retry import RetryPolicy
 
 
 class ThriftContextFactory(ContextFactory):
@@ -21,6 +25,15 @@ class ThriftContextFactory(ContextFactory):
     :param baseplate.thrift_pool.ConnectionPool pool: The connection pool.
     :param client_cls: The class object of a Thrift-generated client class,
         e.g. ``YourService.Client``.
+
+    The proxy object has a ``retrying`` method which takes the same parameters
+    as :py:meth:`RetryPolicy.new <baseplate.retry.RetryPolicy.new>` and acts as
+    a context manager. The context manager returns another proxy object where
+    Thrift service method calls will be automatically retried with the
+    specified retry policy when transient errors occur::
+
+        with context.my_service.retrying(attempts=3) as svc:
+            svc.some_method()
 
     """
     def __init__(self, pool, client_cls):
@@ -52,25 +65,48 @@ def _enumerate_service_methods(client):
 class PooledClientProxy(object):
     """A proxy which acts like a thrift client but uses a connection pool."""
 
-    def __init__(self, client_cls, pool, root_span, namespace):
+    def __init__(self, client_cls, pool, root_span, namespace, retry_policy=None):
         self.client_cls = client_cls
         self.pool = pool
         self.root_span = root_span
         self.namespace = namespace
+        self.retry_policy = retry_policy or RetryPolicy.new(attempts=1)
 
         for name in _enumerate_service_methods(client_cls):
             setattr(self, name, functools.partial(
                 self._call_thrift_method, name))
 
+    @contextlib.contextmanager
+    def retrying(self, **policy):
+        yield PooledClientProxy(
+            self.client_cls,
+            self.pool,
+            self.root_span,
+            self.namespace,
+            retry_policy=RetryPolicy.new(**policy),
+        )
+
     def _call_thrift_method(self, name, *args, **kwargs):
         trace_name = "{}.{}".format(self.namespace, name)
+        last_error = None
 
-        with self.root_span.make_child(trace_name) as span:
-            with self.pool.connection() as prot:
-                prot.trans.set_header("Trace", str(span.trace_id))
-                prot.trans.set_header("Parent", str(span.parent_id))
-                prot.trans.set_header("Span", str(span.id))
+        for _ in self.retry_policy:
+            try:
+                with self.root_span.make_child(trace_name) as span:
+                    with self.pool.connection() as prot:
+                        prot.trans.set_header("Trace", str(span.trace_id))
+                        prot.trans.set_header("Parent", str(span.parent_id))
+                        prot.trans.set_header("Span", str(span.id))
 
-                client = self.client_cls(prot)
-                method = getattr(client, name)
-                return method(*args, **kwargs)
+                        client = self.client_cls(prot)
+                        method = getattr(client, name)
+                        return method(*args, **kwargs)
+            except TTransportException as exc:
+                last_error = exc
+                continue
+        else:
+            raise TTransportException(
+                type=TTransportException.TIMED_OUT,
+                message="retry policy exhausted while attempting operation, "
+                        "last error was: {}".format(last_error),
+            )

--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -60,14 +60,19 @@ def _metric_join(*nodes):
     return b".".join(node.strip(b".") for node in nodes)
 
 
-class NullTransport(object):
+class Transport(object):
+    def send(self, serialized_metric):
+        raise NotImplementedError
+
+
+class NullTransport(Transport):
     """A transport which doesn't send messages at all."""
     def send(self, serialized_metric):
         for metric_line in serialized_metric.splitlines():
             logger.debug("Would send metric %r", metric_line)
 
 
-class RawTransport(object):
+class RawTransport(Transport):
     """A transport which sends messages on a socket."""
     def __init__(self, endpoint):
         self.socket = socket.socket(endpoint.family, socket.SOCK_DGRAM)

--- a/baseplate/retry.py
+++ b/baseplate/retry.py
@@ -118,9 +118,11 @@ class ExponentialBackoffRetryPolicy(RetryPolicy):
 
     def yield_attempts(self):
         for attempt, time_remaining in enumerate(self.subpolicy):
-            yield time_remaining
+            if attempt > 0:
+                delay = self.base * 2**(attempt-1)
+                if time_remaining:
+                    delay = min(delay, time_remaining)
+                    time_remaining -= delay
+                time.sleep(delay)
 
-            delay = self.base * 2**attempt
-            if time_remaining:
-                delay = min(delay, time_remaining)
-            time.sleep(delay)
+            yield time_remaining

--- a/baseplate/retry.py
+++ b/baseplate/retry.py
@@ -1,0 +1,126 @@
+"""Policies for retrying an operation safely."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import time
+
+
+class RetryPolicy(object):
+    """A policy for retrying operations.
+
+    Policies are meant to be used as an iterable::
+
+        for time_remaining in RetryPolicy.new(attempts=3):
+            try:
+                some_operation.do(timeout=time_remaining)
+                break
+            except SomeError:
+                pass
+        else:
+            raise MaxRetriesError
+
+    """
+
+    def yield_attempts(self):
+        """Return an iterator which controls attempts.
+
+        On each iteration, the iterator will yield the number of seconds left
+        to retry, this should be used to set the timeout on the operation
+        being carried out. If there is no maximum time remaining,
+        :py:data:`None` is yielded instead.
+
+        The iterable will raise :py:exc:`StopIteration` once the operation
+        should not be retried any further.
+
+        """
+
+        raise NotImplementedError
+
+    def __iter__(self):
+        """Convenience alias for :py:meth:`yield_attempts`.
+
+        This allows policies to be directly iterated over.
+
+        """
+        return self.yield_attempts()
+
+    @staticmethod
+    def new(attempts=None, budget=None, backoff=None):
+        """Create a new retry policy with the given constraints.
+
+        :param int attempts: The maximum number of times the operation can be
+            attempted.
+        :param float budget: The maximum amount of time, in seconds, that the
+            local service will wait for the operation to succeed.
+        :param float backoff: The base amount of time, in seconds, for
+            exponential backoff between attempts. ``N`` in (``N *
+            2**attempts``).
+
+        """
+        policy = IndefiniteRetryPolicy()
+
+        if attempts is not None:
+            policy = MaximumAttemptsRetryPolicy(policy, attempts)
+
+        if budget is not None:
+            policy = TimeBudgetRetryPolicy(policy, budget)
+
+        if backoff is not None:
+            policy = ExponentialBackoffRetryPolicy(policy, backoff)
+
+        return policy
+
+
+class IndefiniteRetryPolicy(RetryPolicy):  # pragma: noqa
+    """Retry immediately forever."""
+    def yield_attempts(self):
+        while True:
+            yield None
+
+
+class MaximumAttemptsRetryPolicy(RetryPolicy):
+    """Constrain the total number of attempts."""
+    def __init__(self, policy, attempts):
+        self.subpolicy = policy
+        self.attempts = attempts
+
+    def yield_attempts(self):
+        for i, remaining in enumerate(self.subpolicy):
+            if i == self.attempts:
+                break
+            yield remaining
+
+
+class TimeBudgetRetryPolicy(RetryPolicy):
+    """Constrain attempts to an overall time budget."""
+    def __init__(self, policy, budget):
+        self.subpolicy = policy
+        self.budget = budget
+
+    def yield_attempts(self):
+        start_time = time.time()
+
+        for _ in self.subpolicy:
+            elapsed = time.time() - start_time
+            time_remaining = self.budget - elapsed
+            if time_remaining <= 0:
+                break
+            yield time_remaining
+
+
+class ExponentialBackoffRetryPolicy(RetryPolicy):
+    """Sleep exponentially longer between attempts."""
+    def __init__(self, policy, base):
+        self.subpolicy = policy
+        self.base = base
+
+    def yield_attempts(self):
+        for attempt, time_remaining in enumerate(self.subpolicy):
+            yield time_remaining
+
+            delay = self.base * 2**attempt
+            if time_remaining:
+                delay = min(delay, time_remaining)
+            time.sleep(delay)

--- a/baseplate/thrift_pool.py
+++ b/baseplate/thrift_pool.py
@@ -82,7 +82,7 @@ class ThriftConnectionPool(object):
         self.timeout = timeout
 
         self.pool = queue.LifoQueue()
-        for i in range(size):
+        for _ in range(size):
             self.pool.put(None)
 
     def _acquire(self):

--- a/docs/baseplate/retry.rst
+++ b/docs/baseplate/retry.rst
@@ -1,0 +1,10 @@
+baseplate.retry
+===============
+
+.. note:: This module is a low-level helper, many client libraries have
+   protocol-aware retry logic built in. Check your library before using this.
+
+.. automodule:: baseplate.retry
+
+.. autoclass:: RetryPolicy
+   :members: new, yield_attempts, __iter__

--- a/docs/baseplate/thrift_pool.rst
+++ b/docs/baseplate/thrift_pool.rst
@@ -5,12 +5,3 @@ baseplate.thrift_pool
 
 .. autoclass:: ThriftConnectionPool()
    :members:
-
-Exceptions
-----------
-
-.. autoexception:: ThriftPoolError
-
-.. autoexception:: TimeoutError
-
-.. autoexception:: MaxRetriesError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -56,6 +56,7 @@ be used without the framework.
    baseplate.events: Events for the data pipeline <baseplate/events>
    baseplate.message_queue: POSIX IPC Message Queues <baseplate/message_queue>
    baseplate.metrics: Counters and timers for statsd <baseplate/metrics>
+   baseplate.retry: Policies for retrying operations <baseplate/retry>
    baseplate.thrift_pool: A Thrift client connection pool <baseplate/thrift_pool>
 
 Other

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -1,6 +1,7 @@
 aggregator
 app
 backend
+backoff
 config
 Config
 configurables
@@ -12,6 +13,7 @@ Gevent
 healthcheck
 hostname
 INI
+iterable
 lifecycle
 namespace
 predecided

--- a/pylintrc
+++ b/pylintrc
@@ -85,7 +85,7 @@ ignore-comments=yes
 ignore-docstrings=yes
 
 # Ignore imports when computing similarities.
-ignore-imports=no
+ignore-imports=yes
 
 
 [MISCELLANEOUS]

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,5 @@
 tests=tests/
 with-coverage=1
 cover-package=baseplate
+cover-html=1
+cover-html-dir=build/coverage

--- a/tests/unit/events/queue_tests.py
+++ b/tests/unit/events/queue_tests.py
@@ -9,7 +9,6 @@ import unittest
 
 from baseplate.events import (
     Event,
-    EventError,
     EventQueue,
     EventQueueFullError,
     EventTooLargeError,

--- a/tests/unit/retry_tests.py
+++ b/tests/unit/retry_tests.py
@@ -1,0 +1,72 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import itertools
+import unittest
+
+from baseplate.retry import (
+    ExponentialBackoffRetryPolicy,
+    IndefiniteRetryPolicy,
+    MaximumAttemptsRetryPolicy,
+    TimeBudgetRetryPolicy,
+)
+
+from .. import mock
+
+
+class RetryPolicyTests(unittest.TestCase):
+    def test_maximum_attempts(self):
+        base_policy = mock.MagicMock()
+        base_policy.__iter__.return_value = itertools.repeat(1.2)
+        policy = MaximumAttemptsRetryPolicy(base_policy, attempts=3)
+
+        retries = iter(policy)
+        self.assertEqual(next(retries), 1.2)
+        self.assertEqual(next(retries), 1.2)
+        self.assertEqual(next(retries), 1.2)
+        with self.assertRaises(StopIteration):
+            next(retries)
+
+    @mock.patch("time.time", autospec=True)
+    def test_time_budget(self, time):
+        policy = TimeBudgetRetryPolicy(IndefiniteRetryPolicy(), budget=5)
+
+        time.return_value = 0
+        retries = iter(policy)
+        self.assertEqual(next(retries), 5)
+
+        time.return_value = 3
+        for _ in range(100):
+            self.assertEqual(next(retries), 2)
+
+        time.return_value = 7
+        with self.assertRaises(StopIteration):
+            next(retries)
+
+    @mock.patch("time.sleep", autospec=True)
+    def test_exponential_backoff(self, sleep):
+        base_policy = mock.MagicMock()
+        base_policy.__iter__.return_value = itertools.repeat(.9)
+        policy = ExponentialBackoffRetryPolicy(base_policy, base=.1)
+
+        retries = iter(policy)
+        next(retries)
+        self.assertEqual(sleep.call_count, 0)
+
+        next(retries)
+        sleep.assert_called_with(.1)
+
+        next(retries)
+        sleep.assert_called_with(.2)
+
+        next(retries)
+        sleep.assert_called_with(.4)
+
+        next(retries)
+        sleep.assert_called_with(.8)
+
+        # the base policy's lower time remaining takes over here
+        next(retries)
+        sleep.assert_called_with(.9)

--- a/tests/unit/retry_tests.py
+++ b/tests/unit/retry_tests.py
@@ -10,6 +10,7 @@ from baseplate.retry import (
     ExponentialBackoffRetryPolicy,
     IndefiniteRetryPolicy,
     MaximumAttemptsRetryPolicy,
+    RetryPolicy,
     TimeBudgetRetryPolicy,
 )
 
@@ -70,3 +71,46 @@ class RetryPolicyTests(unittest.TestCase):
         # the base policy's lower time remaining takes over here
         next(retries)
         sleep.assert_called_with(.9)
+
+
+class ComplexPolicyTests(unittest.TestCase):
+    @mock.patch("time.sleep", autospec=True)
+    def test_attempts_and_backoff(self, sleep):
+        policy = RetryPolicy.new(backoff=0.2, attempts=3)
+        retries = iter(policy)
+
+        next(retries)
+
+        next(retries)
+        sleep.assert_called_with(0.2)
+
+        next(retries)
+        sleep.assert_called_with(0.4)
+
+        with self.assertRaises(StopIteration):
+            next(retries)
+
+    @mock.patch("time.time", autospec=True)
+    @mock.patch("time.sleep", autospec=True)
+    def test_budget_overrides_backoff(self, sleep, time):
+        policy = RetryPolicy.new(backoff=0.1, budget=1)
+
+        time.return_value = 0
+        retries = iter(policy)
+        time_remaining = next(retries)
+        self.assertAlmostEqual(time_remaining, 1)
+        self.assertEqual(sleep.call_count, 0)
+
+        time.return_value = .5
+        time_remaining = next(retries)
+        self.assertAlmostEqual(time_remaining, .4)
+        sleep.assert_called_with(.1)
+
+        time.return_value = .9
+        time_remaining = next(retries)
+        self.assertAlmostEqual(time_remaining, 0)
+        self.assertAlmostEqual(sleep.call_args[0][0], 0.1, places=2)
+
+        time.return_value = 1
+        with self.assertRaises(StopIteration):
+            next(retries)

--- a/tests/unit/thrift_pool_tests.py
+++ b/tests/unit/thrift_pool_tests.py
@@ -53,7 +53,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
     def test_pool_empty_timeout(self):
         self.mock_queue.get.side_effect = queue.Empty
 
-        with self.assertRaises(thrift_pool.TimeoutError):
+        with self.assertRaises(TTransport.TTransportException):
             self.pool._acquire()
 
     @mock.patch("time.time")
@@ -120,7 +120,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
 
         mock_make_protocol.side_effect = [broken_prot] * 3
 
-        with self.assertRaises(thrift_pool.MaxRetriesError):
+        with self.assertRaises(TTransport.TTransportException):
             self.pool._acquire()
 
     def test_release_open(self):
@@ -172,7 +172,7 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         with self.assertRaises(TException):
             with self.pool.connection() as prot:
                 mock_prot.trans.isOpen.return_value = False
-                raise TException
+                raise TTransport.TTransportException
 
         self.assertEqual(prot, mock_prot)
         self.assertEqual(mock_prot.trans.close.call_count, 1)


### PR DESCRIPTION
There are two big things going on here: the `baseplate.retry` module and then the sugar in `baseplate.context.thrift`. 

The `baseplate.retry` module is a low-level library with "guts exposed". It provides common retry policies in a composable manner. That commit also refactors several places inside baseplate which did their own retry logic to use this module. 

The second part, in `baseplate.context.thrift`, adds some syntactic sugar to the thrift client. By default, the client will continue to do no retries (a policy of `attempts=1`) on remote operations because it cannot know if the operation being done is idempotent or not. The new sugar adds a context manager that allows a retry policy to be applied to service calls made within a `with` statement.

```python
with context.activity_service.retrying(attempts=3) as activity_service:
    return activity_service.count_activity(sr._fullname)
```

I looked at a bunch of prior art and tried various options before settling on this structure. I've written up [some documentation on my thoughts behind the API design](https://gist.github.com/spladug/dc587162fb718d8a9aca2b4eeeb6df69) in case it's helpful.

I also restructured the exception hierarchy from the `thrift_pool` module. I'm taking the tack now that it shouldn't make its own exceptions as it's essentially acting as a "missing piece" from the thrift library itself and so it should integrate with that exception hierarchy properly instead. r2's currently the only user of this module and its use will not be broken by this change, though it could be scoped down further to prevent masking bugs down the line.

There are a couple of other commits here that do minor lint-related stuff that came up while working on this.

:eyeglasses: @bsimpson63 @KeyserSosa @ckwang8128  