### PR TITLE
Make time budgeted retries always execute at least once

### DIFF
--- a/baseplate/retry.py
+++ b/baseplate/retry.py
@@ -107,7 +107,7 @@ class TimeBudgetRetryPolicy(RetryPolicy):
             time_remaining = self.budget - elapsed
             if i > 0 and time_remaining <= 0:
                 break
-            yield time_remaining
+            yield max(0, time_remaining)
 
 
 class ExponentialBackoffRetryPolicy(RetryPolicy):

--- a/baseplate/retry.py
+++ b/baseplate/retry.py
@@ -102,10 +102,10 @@ class TimeBudgetRetryPolicy(RetryPolicy):
     def yield_attempts(self):
         start_time = time.time()
 
-        for _ in self.subpolicy:
+        for i, _ in enumerate(self.subpolicy):
             elapsed = time.time() - start_time
             time_remaining = self.budget - elapsed
-            if time_remaining <= 0:
+            if i > 0 and time_remaining <= 0:
                 break
             yield time_remaining
 

--- a/tests/integration/message_queue_tests.py
+++ b/tests/integration/message_queue_tests.py
@@ -60,6 +60,14 @@ class TestMessageQueueCreation(unittest.TestCase):
             elapsed = time.time() - start
             self.assertAlmostEqual(elapsed, 0.1, places=2)
 
+    def test_put_zero_timeout(self):
+        message_queue = MessageQueue(self.qname, max_messages=1, max_message_size=1)
+
+        with contextlib.closing(message_queue) as mq:
+            mq.put(b"x", timeout=0)
+            message = mq.get()
+            self.assertEqual(message, b"x")
+
     def tearDown(self):
         try:
             queue = posix_ipc.MessageQueue(self.qname)

--- a/tests/unit/retry_tests.py
+++ b/tests/unit/retry_tests.py
@@ -46,6 +46,17 @@ class RetryPolicyTests(unittest.TestCase):
         with self.assertRaises(StopIteration):
             next(retries)
 
+    @mock.patch("time.time", autospec=True)
+    def test_time_budget_always_executes_at_least_once(self, time):
+        policy = TimeBudgetRetryPolicy(IndefiniteRetryPolicy(), budget=0)
+
+        time.return_value = 0
+        retries = iter(policy)
+        self.assertEqual(next(retries), 0)
+
+        with self.assertRaises(StopIteration):
+            next(retries)
+
     @mock.patch("time.sleep", autospec=True)
     def test_exponential_backoff(self, sleep):
         base_policy = mock.MagicMock()


### PR DESCRIPTION
If a time budget of zero is given, this would previously not run the
retried code at all. This is awkward if we want to say "don't block" but
do want to try at least once.

This was breaking EventQueue which uses MessageQueue.put(..., timeout=0)
for non-blocking sends.

Do you think this messes up the concept of a total time budget too much? or is it
more surprising that the code wouldn't run at all?

:eyeglasses: @bsimpson63 @ckwang8128 