### PR TITLE
Logging configuration via INI file

### DIFF
--- a/docs/cli/serve.rst
+++ b/docs/cli/serve.rst
@@ -81,6 +81,20 @@ Thrift
 WSGI
    A WSGI callable.
 
+Logging
+-------
+
+The baseplate server provides a default configuration for the Python standard
+``logging`` system. The root logger will print to ``stdout`` with a format that
+includes trace information. The default log level is ``INFO`` or ``DEBUG`` if
+the ``--debug`` flag is passed to ``baseplate-serve``.
+
+If more complex logging configuration is necessary, the configuration file will
+override the default setup. The `configuration format`_ is documented in the
+standard library.
+
+.. _configuration format: https://docs.python.org/2/library/logging.config.html#logging-config-fileformat
+
 Automatic reload on source changes
 ----------------------------------
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -41,4 +41,4 @@ serving requests::
 For more info on this mysterious ``baseplate-serve2``, check out the `chapter
 about the baseplate server`_.
 
-.. _chapter about the baseplate server: server.html
+.. _chapter about the baseplate server: cli/serve.html


### PR DESCRIPTION
This makes it so if logging configuration is added to the INI file, it will override the default configuration allowing for more flexible / specific settings.

:eyeglasses: @xilvar @bsimpson63 