### PR TITLE
Standardize trace info and add helpers for Pyramid

### DIFF
--- a/baseplate/_utils.py
+++ b/baseplate/_utils.py
@@ -1,0 +1,20 @@
+"""Internal library helpers."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+import warnings
+
+
+def warn_deprecated(message):
+    """Emit a deprecation warning from the caller.
+
+    The stacktrace for the warning will point to the place where the function
+    calling this was called, rather than in baseplate. This allows the user to
+    most easily see where in _their_ code the deprecation is coming from.
+
+    """
+    warnings.warn(message, DeprecationWarning, stacklevel=3)

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -18,6 +18,7 @@ import signal
 import socket
 import sys
 import traceback
+import warnings
 
 from . import einhorn, reloader
 from .._compat import configparser
@@ -72,8 +73,11 @@ def read_config(config_file, server_name, app_name):
 
 
 def configure_logging(config, debug):
+    logging.captureWarnings(capture=True)
+
     if debug:
         logging_level = logging.DEBUG
+        warnings.simplefilter('always')  # enable DeprecationWarning etc.
     else:
         logging_level = logging.INFO
 

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -19,10 +19,11 @@ incomplete example of an application built on the framework::
 
 When a request is made which routes to the ``do_something`` handler, a
 :py:class:`~baseplate.core.RootSpan` is automatically created. If the incoming
-request has trace headers, the root span will be identical to the child span in
-the upstream service. When we call ``request.some_redis_client.ping()`` in the
-handler, Baseplate will create a child :py:class:`~baseplate.core.Span` object
-to represent the time taken talking to redis.
+request has trace headers, we construct the root span to be identical to the
+child span in the upstream service. When we call
+``request.some_redis_client.ping()`` in the handler, Baseplate will create a
+child :py:class:`~baseplate.core.Span` object to represent the time taken
+talking to redis.
 
 The creation of the root and child spans will trigger updates on all the
 :py:class:`~baseplate.core.RootSpanObserver` and
@@ -52,6 +53,9 @@ integrations <integration/index>`.
 .. autoclass:: Baseplate
    :members:
 
+.. autoclass:: TraceInfo
+   :members:
+
 Spans
 -----
 
@@ -76,7 +80,7 @@ else might be helpful.
    :inherited-members:
 
 .. autoclass:: Span
-   :members:
+   :members: from_upstream
 
 Observers
 ---------

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,10 @@ setup(
         "console_scripts": [
             "baseplate-healthcheck{:d} = baseplate.server.healthcheck:run_healthchecks".format(sys.version_info.major),
         ],
+
+        "paste.app_factory": [
+            "main = baseplate.integration.pyramid:paste_make_app",
+        ],
     },
 
     classifiers=[

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -54,7 +54,10 @@ class ThriftTests(unittest.TestCase):
         self.processor = BaseplateService.ContextProcessor(handler)
         self.processor.setEventHandler(event_handler)
 
-    def test_no_headers(self):
+    @mock.patch("random.getrandbits")
+    def test_no_trace_headers(self, getrandbits):
+        getrandbits.return_value = 1234
+
         client_memory_trans = TMemoryBuffer()
         client_prot = THeaderProtocol(client_memory_trans)
         client = BaseplateService.Client(client_prot)
@@ -69,9 +72,9 @@ class ThriftTests(unittest.TestCase):
         self.assertEqual(self.observer.on_root_span_created.call_count, 1)
 
         context, root_span = self.observer.on_root_span_created.call_args[0]
-        self.assertEqual(root_span.trace_id, "no-trace")
-        self.assertEqual(root_span.parent_id, "no-parent")
-        self.assertEqual(root_span.id, "no-span")
+        self.assertEqual(root_span.trace_id, 1234)
+        self.assertEqual(root_span.parent_id, None)
+        self.assertEqual(root_span.id, 1234)
 
         self.assertTrue(self.root_observer.on_start.called)
         self.assertTrue(self.root_observer.on_stop.called)
@@ -95,9 +98,9 @@ class ThriftTests(unittest.TestCase):
         self.assertEqual(self.observer.on_root_span_created.call_count, 1)
 
         context, root_span = self.observer.on_root_span_created.call_args[0]
-        self.assertEqual(root_span.trace_id, "1234")
-        self.assertEqual(root_span.parent_id, "2345")
-        self.assertEqual(root_span.id, "3456")
+        self.assertEqual(root_span.trace_id, 1234)
+        self.assertEqual(root_span.parent_id, 2345)
+        self.assertEqual(root_span.id, 3456)
 
         self.assertTrue(self.root_observer.on_start.called)
         self.assertTrue(self.root_observer.on_stop.called)

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -12,6 +12,7 @@ from baseplate.core import (
     RootSpanObserver,
     Span,
     SpanObserver,
+    TraceInfo,
 )
 
 from .. import mock
@@ -24,7 +25,7 @@ class BaseplateTests(unittest.TestCase):
 
         baseplate = Baseplate()
         baseplate.register(mock_observer)
-        root_span = baseplate.make_root_span(mock_context, 1, 2, "name", 3)
+        root_span = baseplate.make_root_span(mock_context, "name", TraceInfo(1, 2, 3))
 
         self.assertEqual(baseplate.observers, [mock_observer])
         self.assertEqual(mock_observer.on_root_span_created.call_count, 1)
@@ -38,7 +39,7 @@ class BaseplateTests(unittest.TestCase):
 
         baseplate = Baseplate()
         baseplate.register(mock_observer)
-        root_span = baseplate.make_root_span(mock_context, 1, 2, "name", 3)
+        root_span = baseplate.make_root_span(mock_context, "name", TraceInfo(1, 2, 3))
 
         self.assertEqual(root_span.observers, [])
 


### PR DESCRIPTION
This is a bundle of minor enhancements. See the individual commit messages for more details.

Once the trace info stuff is in place, we can get the gateway service to generate traces and pass them into r2 so we can correlate those requests in logs.

:eyeglasses: @bsimpson63 @dellis23 @xilvar