### PR TITLE
Clarify docstring for config module outside baseplate-serve

### DIFF
--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -10,7 +10,9 @@ For example, an INI file like the following:
 .. include:: ../config_example.ini
    :literal:
 
-Might be parsed like this:
+Might be parsed like the following. Note: when running under the baseplate
+server, The ``config_parser.items(...)`` step is taken care of for you and
+``raw_config`` is passed as the only argument to your factory function.
 
 .. highlight:: py
 
@@ -24,9 +26,6 @@ Might be parsed like this:
 .. doctest::
 
     >>> raw_config = dict(config_parser.items("app:main"))
-    # note: when running under baseplate-serve, your factory
-    # function will receive this raw_config as its only argument.
-    # the above step is just here to make clear the expected format.
 
     >>> CARDS = config.OneOf(clubs=1, spades=2, diamonds=3, hearts=4)
     >>> cfg = config.parse_config(raw_config, {

--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -7,13 +7,8 @@ For example, an INI file like the following:
 
 .. highlight:: ini
 
-::
-
-    [app:main]
-    simple = true
-    cards = clubs, spades, diamonds
-    nested.once = 1
-    nested.really.deep = 3 seconds
+.. include:: ../config_example.ini
+   :literal:
 
 Might be parsed like this:
 
@@ -22,14 +17,16 @@ Might be parsed like this:
 .. testsetup::
 
     from baseplate import config
-    raw_config = {
-        "simple": "true",
-        "cards": "clubs, spades, diamonds",
-        "nested.once": "1",
-        "nested.really.deep": "3 seconds",
-    }
+    from baseplate._compat import configparser
+    config_parser = configparser.ConfigParser()
+    config_parser.readfp(open("docs/config_example.ini"))
 
 .. doctest::
+
+    >>> raw_config = dict(config_parser.items("app:main"))
+    # note: when running under baseplate-serve, your factory
+    # function will receive this raw_config as its only argument.
+    # the above step is just here to make clear the expected format.
 
     >>> CARDS = config.OneOf(clubs=1, spades=2, diamonds=3, hearts=4)
     >>> cfg = config.parse_config(raw_config, {

--- a/docs/config_example.ini
+++ b/docs/config_example.ini
@@ -1,0 +1,5 @@
+[app:main]
+simple = true
+cards = clubs, spades, diamonds
+nested.once = 1
+nested.really.deep = 3 seconds


### PR DESCRIPTION
This makes it obvious what the expected input to the parse_config
function should be like.

:eyeglasses: @dellis23 @gtaylor 