### PR TITLE
Get pedantic about and enforce style

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ virtualenv:
 before_install:
     - sudo add-apt-repository -y ppa:reddit/ppa
     - sudo apt-get update -q
-    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34
+    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34 pep8 pylint
 
 install:
     - pip install -e ".[gevent,pyramid]"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ virtualenv:
 before_install:
     - sudo add-apt-repository -y ppa:reddit/ppa
     - sudo apt-get update -q
-    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34 pep8 pylint
+    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34 pep8 pylint python-redis python-gevent
 
 install:
-    - pip install -e ".[gevent,pyramid]"
+    - pip install -e ".[pyramid]"
     - pip install webtest coverage
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ script:
     - nosetests
     - sphinx-build -M doctest docs/ build/
     - sphinx-build -M spelling docs/ build/
+    - make lint

--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,9 @@ install:
 	python2 setup.py install
 	python3 setup.py install
 
+lint:
+	pep8 --repeat --ignore=E501,E128,E226 --exclude=baseplate/thrift/ baseplate/
+	pylint --errors-only baseplate/
 
-.PHONY: docs spelling clean realclean tests develop install build
+
+.PHONY: docs spelling clean realclean tests develop install build lint

--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -31,6 +31,7 @@ def make_metrics_client(raw_config):
         },
     })
 
+    # pylint: disable=no-member
     return metrics.make_client(cfg.metrics.namespace, cfg.metrics.endpoint)
 
 

--- a/baseplate/_compat.py
+++ b/baseplate/_compat.py
@@ -1,3 +1,4 @@
+# pylint: disable=import-error
 """Python 3 compatibility."""
 
 from __future__ import absolute_import

--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 """Configuration parsing and validation.
 
 This module provides ``parse_config`` which turns a dictionary of stringy keys
@@ -64,6 +65,7 @@ import socket
 class ConfigurationError(Exception):
     """Raised when the configuration violates the spec."""
     def __init__(self, key, error):
+        super(ConfigurationError, self).__init__()
         self.key = key
         self.error = error
 
@@ -143,8 +145,8 @@ def Endpoint(text):
         host, sep, port = text.partition(":")
         if sep != ":":
             raise ValueError("no port specified")
-        return EndpointConfiguration(socket.AF_INET,
-            InternetAddress(host, int(port)))
+        address = InternetAddress(host, int(port))
+        return EndpointConfiguration(socket.AF_INET, address)
 
 
 def Base64(text):
@@ -243,6 +245,7 @@ def Optional(T, default=None):
 
 class ConfigNamespace(dict):
     def __init__(self):
+        super(ConfigNamespace, self).__init__()
         self.__dict__ = self
 
 

--- a/baseplate/context/cassandra.py
+++ b/baseplate/context/cassandra.py
@@ -26,7 +26,7 @@ class CassandraContextFactory(ContextFactory):
         return CassandraSessionAdapter(name, root_span, self.session)
 
 
-def _on_execute_complete(rows, span):
+def _on_execute_complete(_, span):
     # TODO: annotate with anything from the result set?
     # TODO: annotate with any returned warnings
     span.stop()

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -31,6 +31,7 @@ class RedisContextFactory(ContextFactory):
         return MonitoredRedisConnection(name, root_span, self.connection_pool)
 
 
+# pylint: disable=too-many-public-methods
 class MonitoredRedisConnection(redis.StrictRedis):
     """Redis connection that collects diagnostic information.
 
@@ -59,6 +60,7 @@ class MonitoredRedisConnection(redis.StrictRedis):
             return super(MonitoredRedisConnection, self).execute_command(
                 command, *args, **kwargs)
 
+    # pylint: disable=arguments-differ
     def pipeline(self, name, transaction=True, shard_hint=None):
         """Create a pipeline.
 

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -48,11 +48,12 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
         self.threadlocal.current_span = None
         return self.engine
 
+    # pylint: disable=unused-argument, too-many-arguments
     def on_before_execute(self, conn, cursor, statement, parameters, context, executemany):
         """Handle the engine's before_cursor_execute event."""
         # http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#is-the-session-thread-safe
         assert self.threadlocal.current_span is None, \
-               "sqlalchemy sessions cannot be used concurrently"
+            "sqlalchemy sessions cannot be used concurrently"
 
         trace_name = "{}.{}".format(self.threadlocal.context_name, "execute")
         span = self.threadlocal.root_span.make_child(trace_name)
@@ -66,6 +67,7 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
             statement, span.trace_id, span.id)
         return annotated_statement, parameters
 
+    # pylint: disable=unused-argument, too-many-arguments
     def on_after_execute(self, conn, cursor, statement, parameters, context, executemany):
         """Handle the engine's after_cursor_execute event."""
         self.threadlocal.current_span.stop()

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -65,6 +65,7 @@ def _enumerate_service_methods(client):
 class PooledClientProxy(object):
     """A proxy which acts like a thrift client but uses a connection pool."""
 
+    # pylint: disable=too-many-arguments
     def __init__(self, client_cls, pool, root_span, namespace, retry_policy=None):
         self.client_cls = client_cls
         self.pool = pool
@@ -104,9 +105,9 @@ class PooledClientProxy(object):
             except TTransportException as exc:
                 last_error = exc
                 continue
-        else:
-            raise TTransportException(
-                type=TTransportException.TIMED_OUT,
-                message="retry policy exhausted while attempting operation, "
-                        "last error was: {}".format(last_error),
-            )
+
+        raise TTransportException(
+            type=TTransportException.TIMED_OUT,
+            message="retry policy exhausted while attempting operation, "
+                    "last error was: {}".format(last_error),
+        )

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -200,6 +200,7 @@ class Baseplate(object):
 class Span(object):
     """A span represents a single RPC within a system."""
 
+    # pylint: disable=invalid-name
     def __init__(self, trace_id, parent_id, span_id, name):
         self.trace_id = trace_id
         self.parent_id = parent_id

--- a/baseplate/crypto.py
+++ b/baseplate/crypto.py
@@ -18,6 +18,7 @@ import time
 
 if hasattr(hmac, "compare_digest"):
     # This was added in Python 2.7.7 and 3.3
+    # pylint: disable=invalid-name,no-member
     constant_time_compare = hmac.compare_digest
 else:
     def constant_time_compare(actual, expected):
@@ -124,7 +125,7 @@ class MessageSigner(object):
 
     def _compute_digest(self, header, message):
         payload = header + message.encode("utf8")
-        digest = hmac.new(self.secret_key, payload, hashlib.sha256).digest()
+        digest = hmac.new(self.secret_key, payload, hashlib.sha256).digest()  # pylint: disable=no-member
         return digest
 
     def make_signature(self, message, max_age):
@@ -164,7 +165,7 @@ class MessageSigner(object):
             version, expiration = _HEADER_FORMAT.unpack(header)
             if version != 1:
                 raise ValueError
-            if len(signature_digest) != hashlib.sha256().digest_size:
+            if len(signature_digest) != hashlib.sha256().digest_size:  # pylint: disable=no-member
                 raise ValueError
         except (struct.error, KeyError, binascii.Error, TypeError, ValueError):
             raise UnreadableSignatureError

--- a/baseplate/events/__init__.py
+++ b/baseplate/events/__init__.py
@@ -3,8 +3,8 @@ from __future__ import division
 from __future__ import print_function
 #from __future__ import unicode_literals This breaks __all__ on PY2
 
-MAX_EVENT_SIZE=102400
-MAX_QUEUE_SIZE=10000
+MAX_EVENT_SIZE = 102400
+MAX_QUEUE_SIZE = 10000
 
 from .queue import (
     Event,

--- a/baseplate/events/publisher.py
+++ b/baseplate/events/publisher.py
@@ -77,8 +77,8 @@ class Batcher(object):
 
 def gzip_compress(content):
     buf = BytesIO()
-    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9) as f:
-        f.write(content)
+    with gzip.GzipFile(fileobj=buf, mode="wb", compresslevel=9) as gzip_file:
+        gzip_file.write(content)
     return buf.getvalue()
 
 

--- a/baseplate/events/queue.py
+++ b/baseplate/events/queue.py
@@ -28,6 +28,7 @@ from baseplate.message_queue import MessageQueue, TimedOutError
 from baseplate._utils import warn_deprecated
 
 
+# pylint: disable=pointless-string-statement,no-init
 class FieldKind(Enum):
     """Enum of field kinds."""
     NORMAL = None
@@ -50,6 +51,7 @@ class FieldKind(Enum):
 
 class Event(object):
     """An event."""
+    # pylint: disable=invalid-name,redefined-builtin
     def __init__(self, topic, event_type, timestamp=None, id=None):
         self.topic = topic
         self.event_type = event_type

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -30,6 +30,7 @@ from ..core import TraceInfo
 from ..server import make_app
 
 
+# pylint: disable=abstract-class-not-used
 class BaseplateConfigurator(object):
     """Config extension to integrate Baseplate into Pyramid.
 
@@ -80,6 +81,7 @@ class BaseplateConfigurator(object):
         )
         request.trace.start()
 
+    # pylint: disable=no-self-use
     def _on_new_response(self, event):
         if not event.request.matched_route:
             return
@@ -105,7 +107,7 @@ class BaseplateConfigurator(object):
         config.add_request_method(start_root_span, "start_root_span")
 
 
-def paste_make_app(global_config, **local_config):
+def paste_make_app(_, **local_config):
     """Make an application object, PasteDeploy style.
 
     This is a compatibility shim to adapt the baseplate app entrypoint to
@@ -121,6 +123,7 @@ def paste_make_app(global_config, **local_config):
 
 
 def pshell_setup(env):
+    # pylint: disable=line-too-long
     """Start a root span when pshell starts up.
 
     This simply starts a root span after the shell initializes, which

--- a/baseplate/message_queue.py
+++ b/baseplate/message_queue.py
@@ -56,14 +56,14 @@ class MessageQueue(object):
         """
         for time_remaining in RetryPolicy.new(budget=timeout):
             try:
-                message, priority = self.queue.receive()
+                message, _ = self.queue.receive()
                 return message
             except posix_ipc.SignalError:  # pragma: nocover
                 continue  # interrupted, just try again
             except posix_ipc.BusyError:
                 select.select([self.queue.mqd], [], [], time_remaining)
-        else:
-            raise TimedOutError
+
+        raise TimedOutError
 
     def put(self, message, timeout=None):
         """Add a message to the queue.
@@ -81,8 +81,8 @@ class MessageQueue(object):
                 continue  # interrupted, just try again
             except posix_ipc.BusyError:
                 select.select([], [self.queue.mqd], [], time_remaining)
-        else:
-            raise TimedOutError
+
+        raise TimedOutError
 
     def unlink(self):
         """Remove the queue from the system.

--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -167,6 +167,7 @@ class Batch(BaseClient):
 
     """
 
+    # pylint: disable=super-init-not-called
     def __init__(self, transport, namespace):
         self.transport = BufferedTransport(transport)
         self.namespace = namespace

--- a/baseplate/requests.py
+++ b/baseplate/requests.py
@@ -19,7 +19,9 @@ import urllib3.connectionpool
 # https://github.com/msabramo/requests-unixsocket/blob/master/requests_unixsocket/adapters.py
 # https://github.com/docker/docker-py/blob/master/docker/unixconn/unixconn.py
 
+
 class _UNIXConnection(urllib3.connectionpool.HTTPConnection):
+    # pylint: disable=super-init-not-called
     def __init__(self, url):
         urllib3.connectionpool.HTTPConnection.__init__(self, "localhost")
         self.url = urlparse.urlparse(url)

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -136,7 +136,7 @@ def make_app(app_config):
 
 
 def register_signal_handlers():
-    def _handle_debug_signal(signal_number, frame):
+    def _handle_debug_signal(_, frame):
         if not frame:
             logger.warning("Received SIGUSR1, but no frame found.")
             return

--- a/baseplate/server/einhorn.py
+++ b/baseplate/server/einhorn.py
@@ -49,7 +49,7 @@ def get_socket(index=0):
         raise NotEinhornWorker
 
     fd_count = get_socket_count()
-    if not (0 <= index < fd_count):
+    if not 0 <= index < fd_count:
         raise IndexError
 
     fileno = int(os.environ["EINHORN_FD_%d" % index])

--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -14,6 +14,7 @@ from thrift.transport.TTransport import (
     TTransportException, TBufferedTransportFactory)
 
 
+# pylint: disable=too-many-public-methods
 class GeventServer(StreamServer):
     def __init__(self, processor, *args, **kwargs):
         self.processor = processor
@@ -26,7 +27,8 @@ class GeventServer(StreamServer):
         signal.signal(signal.SIGTERM, lambda sig, frame: self.stop())
         super(GeventServer, self).serve_forever(stop_timeout=stop_timeout)
 
-    def handle(self, client_socket, address):
+    # pylint: disable=method-hidden
+    def handle(self, client_socket, _):
         client = TSocket()
         client.setHandle(client_socket)
 

--- a/baseplate/server/wsgi.py
+++ b/baseplate/server/wsgi.py
@@ -12,12 +12,13 @@ from gevent.pywsgi import WSGIServer
 from . import _load_factory
 
 try:
+    # pylint: disable=no-name-in-module
     from gevent.pywsgi import LoggingLogAdapter
 except ImportError:
     # LoggingLogAdapter is from gevent 1.1+
     class LoggingLogAdapter(object):
-        def __init__(self, logger, level):
-            self._logger = logger
+        def __init__(self, logger_, level):
+            self._logger = logger_
             self._level = level
 
         def write(self, msg):
@@ -43,6 +44,7 @@ def make_server(config, listener, app):
     if handler:
         kwargs["handler_class"] = _load_factory(handler, default_name=None)
 
+    # pylint: disable=star-args
     server = WSGIServer(
         listener,
         application=app,

--- a/baseplate/thrift_pool.py
+++ b/baseplate/thrift_pool.py
@@ -55,6 +55,7 @@ class ThriftConnectionPool(object):
     :py:exc:`~thrift.transport.TTransport.TTransportException`.
 
     """
+    # pylint: disable=too-many-arguments
     def __init__(self, endpoint, size=10, max_age=120, timeout=1, max_retries=3):
         self.endpoint = endpoint
         self.max_age = max_age
@@ -96,11 +97,11 @@ class ThriftConnectionPool(object):
             prot.baseplate_birthdate = time.time()
 
             return prot
-        else:
-            raise TTransportException(
-                type=TTransportException.NOT_OPEN,
-                message="giving up after multiple attempts to connect",
-            )
+
+        raise TTransportException(
+            type=TTransportException.NOT_OPEN,
+            message="giving up after multiple attempts to connect",
+        )
 
     def _release(self, prot):
         if prot.trans.isOpen():

--- a/pylintrc
+++ b/pylintrc
@@ -111,7 +111,7 @@ additional-builtins=
 [FORMAT]
 
 # Maximum number of characters on a single line.
-max-line-length=80
+max-line-length=100
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$


### PR DESCRIPTION
Make pylint happy by either fixing various little nits or explicitly
disabling checks on a site-by-site basis. I've opted to boost the
programatically enforced line-length limit to 100 characters, but we
should still aim to stay <80 where possible.

This also adds a "make lint" which gets run during CI to ensure we stay
on our toes here.

:eyeglasses: @dellis23 @dwick 