### PR TITLE
OpenTracing standardization and exception catching fixes

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -40,7 +40,7 @@ class ContextFactory(object):
 
     """
 
-    def make_object_for_context(self, name, root_span):  # pragma: nocover
+    def make_object_for_context(self, name, server_span):  # pragma: nocover
         """Return an object that can be added to the context object."""
         raise NotImplementedError
 
@@ -50,6 +50,6 @@ class ContextObserver(BaseplateObserver):
         self.name = name
         self.context_factory = context_factory
 
-    def on_root_span_created(self, context, root_span):
-        context_attr = self.context_factory.make_object_for_context(self.name, root_span)
+    def on_server_span_created(self, context, server_span):
+        context_attr = self.context_factory.make_object_for_context(self.name, server_span)
         setattr(context, self.name, context_attr)

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -108,5 +108,5 @@ class SQLAlchemySessionRootSpanObserver(RootSpanObserver):
     def __init__(self, session):
         self.session = session
 
-    def on_stop(self, error):
+    def on_stop(self, exc_info):
         self.session.close()

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -36,11 +36,11 @@ class SpanObserver(object):  # pragma: nocover
         """Called when an annotation is added to the observed span."""
         pass
 
-    def on_stop(self, error):
+    def on_stop(self, exc_info):
         """Called when the observed span is stopped.
 
-        :param error: If the span ended because of an exception, the instance
-            raised. Otherwise, :py:data:`None`.
+        :param exc_info: If the span ended because of an exception, the
+            exception info. Otherwise, :py:data:`None`.
 
         """
         pass
@@ -244,23 +244,26 @@ class Span(object):
         for observer in self.observers:
             observer.on_annotate(key, value)
 
-    def stop(self, error=None):
+    def stop(self, exc_info=None):
         """Record the end of the span.
 
-        :param error: If the span ended because of an exception, this should
-            be that exception. The default is :py:data:`None` which indicates
-            normal exit.
+        :param exc_info: If the span ended because of an exception, this is
+            the exception information. The default is :py:data:`None` which
+            indicates normal exit.
 
         """
         for observer in self.observers:
-            observer.on_stop(error=error)
+            observer.on_stop(exc_info)
 
     def __enter__(self):
         self.start()
         return self
 
     def __exit__(self, exc_type, value, traceback):
-        self.stop(error=value)
+        if exc_type is not None:
+            self.stop(exc_info=(exc_type, value, traceback))
+        else:
+            self.stop()
 
 
 class RootSpan(Span):

--- a/baseplate/diagnostics/logging.py
+++ b/baseplate/diagnostics/logging.py
@@ -16,5 +16,5 @@ class LoggingBaseplateObserver(BaseplateObserver):
     the thread name to the current request's trace ID.
 
     """
-    def on_root_span_created(self, context, root_span):  # pragma: nocover
-        threading.current_thread().name = str(root_span.trace_id)
+    def on_server_span_created(self, context, server_span):  # pragma: nocover
+        threading.current_thread().name = str(server_span.trace_id)

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -42,7 +42,7 @@ class MetricsSpanObserver(SpanObserver):
     def on_annotate(self, key, value):  # pragma: nocover
         pass
 
-    def on_stop(self, error):
+    def on_stop(self, exc_info):
         self.timer.stop()
 
 
@@ -51,6 +51,6 @@ class MetricsRootSpanObserver(MetricsSpanObserver):
         observer = MetricsSpanObserver(self.batch, "clients." + span.name)
         span.register(observer)
 
-    def on_stop(self, error):
-        super(MetricsRootSpanObserver, self).on_stop(error)
+    def on_stop(self, exc_info):
+        super(MetricsRootSpanObserver, self).on_stop(exc_info)
         self.batch.flush()

--- a/baseplate/events/queue.py
+++ b/baseplate/events/queue.py
@@ -179,5 +179,5 @@ class EventQueue(ContextFactory):
         except TimedOutError:
             raise EventQueueFullError
 
-    def make_object_for_context(self, name, root_span):
+    def make_object_for_context(self, name, server_span):
         return self

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -71,10 +71,10 @@ class BaseplateConfigurator(object):
             except (KeyError, ValueError):
                 pass
 
-        request.start_root_span(request.matched_route.name, trace_info)
+        request.start_server_span(request.matched_route.name, trace_info)
 
-    def _start_root_span(self, request, name, trace_info=None):
-        request.trace = self.baseplate.make_root_span(
+    def _start_server_span(self, request, name, trace_info=None):
+        request.trace = self.baseplate.make_server_span(
             request,
             name=name,
             trace_info=trace_info,
@@ -86,7 +86,7 @@ class BaseplateConfigurator(object):
         if not event.request.matched_route:
             return
 
-        event.request.trace.stop()
+        event.request.trace.finish()
 
     def includeme(self, config):
         config.add_subscriber(self._on_new_request, ContextFound)
@@ -102,9 +102,9 @@ class BaseplateConfigurator(object):
         # pyramid gets all cute with descriptors and will pass the request
         # object as the first ("self") param to bound methods. wrapping
         # the bound method in a simple function prevents that behavior
-        def start_root_span(*args, **kwargs):
-            return self._start_root_span(*args, **kwargs)
-        config.add_request_method(start_root_span, "start_root_span")
+        def start_server_span(*args, **kwargs):
+            return self._start_server_span(*args, **kwargs)
+        config.add_request_method(start_server_span, "start_server_span")
 
 
 def paste_make_app(_, **local_config):
@@ -124,9 +124,9 @@ def paste_make_app(_, **local_config):
 
 def pshell_setup(env):
     # pylint: disable=line-too-long
-    """Start a root span when pshell starts up.
+    """Start a server span when pshell starts up.
 
-    This simply starts a root span after the shell initializes, which
+    This simply starts a server span after the shell initializes, which
     gives shell users access to all the :term:`context object` goodness.
 
     To use it, add configuration to your app's INI file like so:
@@ -137,4 +137,4 @@ def pshell_setup(env):
     See http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/commandline.html#extending-the-shell
 
     """
-    env["request"].start_root_span("shell")
+    env["request"].start_server_span("shell")

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -60,7 +60,7 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
             pass
 
         context.headers = headers
-        context.trace = self.baseplate.make_root_span(
+        context.trace = self.baseplate.make_server_span(
             context,
             name=fn_name,
             trace_info=trace_info,
@@ -72,7 +72,7 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
         handler_context.trace.start()
 
     def handlerDone(self, handler_context, fn_name, result):
-        handler_context.trace.stop()
+        handler_context.trace.finish()
 
     def handlerError(self, handler_context, fn_name, exception):
         self.logger.exception("Unexpected exception in %r.", fn_name)

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -10,7 +10,7 @@ import unittest
 import webtest
 
 from baseplate import Baseplate
-from baseplate.core import BaseplateObserver, RootSpanObserver
+from baseplate.core import BaseplateObserver, ServerSpanObserver
 from baseplate.integration.pyramid import BaseplateConfigurator
 from pyramid.config import Configurator
 from pyramid.request import Request
@@ -30,10 +30,10 @@ class ConfiguratorTests(unittest.TestCase):
             example_application, route_name="example", renderer="json")
 
         self.observer = mock.Mock(spec=BaseplateObserver)
-        self.root_observer = mock.Mock(spec=RootSpanObserver)
-        def _register_mock(context, root_span):
-            root_span.register(self.root_observer)
-        self.observer.on_root_span_created.side_effect = _register_mock
+        self.server_observer = mock.Mock(spec=ServerSpanObserver)
+        def _register_mock(context, server_span):
+            server_span.register(self.server_observer)
+        self.observer.on_server_span_created.side_effect = _register_mock
 
         self.baseplate = Baseplate()
         self.baseplate.register(self.observer)
@@ -50,16 +50,16 @@ class ConfiguratorTests(unittest.TestCase):
         getrandbits.return_value = 1234
         self.test_app.get("/example")
 
-        self.assertEqual(self.observer.on_root_span_created.call_count, 1)
+        self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
-        context, root_span = self.observer.on_root_span_created.call_args[0]
+        context, server_span = self.observer.on_server_span_created.call_args[0]
         self.assertIsInstance(context, Request)
-        self.assertEqual(root_span.trace_id, 1234)
-        self.assertEqual(root_span.parent_id, None)
-        self.assertEqual(root_span.id, 1234)
+        self.assertEqual(server_span.trace_id, 1234)
+        self.assertEqual(server_span.parent_id, None)
+        self.assertEqual(server_span.id, 1234)
 
-        self.assertTrue(self.root_observer.on_start.called)
-        self.assertTrue(self.root_observer.on_stop.called)
+        self.assertTrue(self.server_observer.on_start.called)
+        self.assertTrue(self.server_observer.on_finish.called)
 
     def test_trace_headers(self):
         self.test_app.get("/example", headers={
@@ -68,21 +68,21 @@ class ConfiguratorTests(unittest.TestCase):
             "X-Span": "3456",
         })
 
-        self.assertEqual(self.observer.on_root_span_created.call_count, 1)
+        self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
-        context, root_span = self.observer.on_root_span_created.call_args[0]
+        context, server_span = self.observer.on_server_span_created.call_args[0]
         self.assertIsInstance(context, Request)
-        self.assertEqual(root_span.trace_id, 1234)
-        self.assertEqual(root_span.parent_id, 2345)
-        self.assertEqual(root_span.id, 3456)
+        self.assertEqual(server_span.trace_id, 1234)
+        self.assertEqual(server_span.parent_id, 2345)
+        self.assertEqual(server_span.id, 3456)
 
-        self.assertTrue(self.root_observer.on_start.called)
-        self.assertTrue(self.root_observer.on_stop.called)
+        self.assertTrue(self.server_observer.on_start.called)
+        self.assertTrue(self.server_observer.on_finish.called)
 
     def test_not_found(self):
         self.test_app.get("/nope", status=404)
 
-        self.assertFalse(self.observer.on_root_span_created.called)
+        self.assertFalse(self.observer.on_server_span_created.called)
 
     @mock.patch("random.getrandbits")
     def test_distrust_headers(self, getrandbits):
@@ -95,7 +95,7 @@ class ConfiguratorTests(unittest.TestCase):
             "X-Span": "3456",
         })
 
-        context, root_span = self.observer.on_root_span_created.call_args[0]
-        self.assertEqual(root_span.trace_id, getrandbits.return_value)
-        self.assertEqual(root_span.parent_id, None)
-        self.assertEqual(root_span.id, getrandbits.return_value)
+        context, server_span = self.observer.on_server_span_created.call_args[0]
+        self.assertEqual(server_span.trace_id, getrandbits.return_value)
+        self.assertEqual(server_span.parent_id, None)
+        self.assertEqual(server_span.id, getrandbits.return_value)

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -11,9 +11,13 @@ import webtest
 
 from baseplate import Baseplate
 from baseplate.core import BaseplateObserver, ServerSpanObserver
-from baseplate.integration.pyramid import BaseplateConfigurator
-from pyramid.config import Configurator
-from pyramid.request import Request
+
+try:
+    from baseplate.integration.pyramid import BaseplateConfigurator
+    from pyramid.config import Configurator
+    from pyramid.request import Request
+except ImportError:
+    raise unittest.SkipTest("pyramid is not installed")
 
 from .. import mock
 

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -12,7 +12,7 @@ except ImportError:
     raise unittest.SkipTest("sqlalchemy is not installed")
 
 from baseplate.context.sqlalchemy import SQLAlchemySessionContextFactory
-from baseplate.core import RootSpan, Span
+from baseplate.core import ServerSpan, Span
 
 from .. import mock
 
@@ -34,16 +34,16 @@ class SQLAlchemyTests(unittest.TestCase):
         self.factory = SQLAlchemySessionContextFactory(self.engine)
 
     def test_session(self):
-        root_span = mock.Mock(autospec=RootSpan)
+        server_span = mock.Mock(autospec=ServerSpan)
         span = mock.Mock(autospec=Span)
         span.id = 1234
         span.trace_id = 2345
-        root_span.make_child.return_value = span
-        session = self.factory.make_object_for_context("db", root_span)
+        server_span.make_child.return_value = span
+        session = self.factory.make_object_for_context("db", server_span)
 
         new_object = TestObject(name="cool")
         session.add(new_object)
         session.commit()
 
-        self.assertEqual(root_span.make_child.call_args,
+        self.assertEqual(server_span.make_child.call_args,
                          mock.call("db.execute"))

--- a/tests/unit/context/tests.py
+++ b/tests/unit/context/tests.py
@@ -18,7 +18,7 @@ class ContextObserverTests(unittest.TestCase):
         mock_span = mock.Mock(spec=Span)
 
         observer = ContextObserver("some_attribute", mock_factory)
-        observer.on_root_span_created(mock_context, mock_span)
+        observer.on_server_span_created(mock_context, mock_span)
 
         self.assertEqual(mock_context.some_attribute,
             mock_factory.make_object_for_context.return_value)

--- a/tests/unit/context/thrift_tests.py
+++ b/tests/unit/context/thrift_tests.py
@@ -61,14 +61,14 @@ class PooledClientProxyTests(unittest.TestCase):
         self.mock_pool = mock.MagicMock(spec=thrift_pool.ThriftConnectionPool)
         self.mock_client_cls = mock.Mock(spec=BaseplateService.Client)
         self.mock_client = self.mock_client_cls.return_value
-        self.mock_root_span = mock.MagicMock(spec=core.RootSpan)
+        self.mock_server_span = mock.MagicMock(spec=core.ServerSpan)
 
     @mock.patch("baseplate.context.thrift._enumerate_service_methods")
     def test_proxy_methods_attached(self, mock_enumerate):
         mock_enumerate.return_value = ["one", "two"]
 
         proxy = thrift.PooledClientProxy(
-            self.mock_client_cls, self.mock_pool, self.mock_root_span, "namespace")
+            self.mock_client_cls, self.mock_pool, self.mock_server_span, "namespace")
 
         self.assertTrue(callable(proxy.one))
         self.assertTrue(callable(proxy.two))
@@ -78,9 +78,9 @@ class PooledClientProxyTests(unittest.TestCase):
         mock_enumerate.return_value = ["one", "two"]
 
         proxy = thrift.PooledClientProxy(
-            self.mock_client_cls, self.mock_pool, self.mock_root_span, "namespace")
+            self.mock_client_cls, self.mock_pool, self.mock_server_span, "namespace")
         result = proxy.one(mock.sentinel.first, mock.sentinel.second)
 
         self.assertEqual(self.mock_client.one.call_count, 1)
         self.assertEqual(result, self.mock_client.one.return_value)
-        self.assertEqual(self.mock_root_span.make_child.call_args, mock.call("namespace.one"))
+        self.assertEqual(self.mock_server_span.make_child.call_args, mock.call("namespace.one"))

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -58,7 +58,7 @@ class SpanTests(unittest.TestCase):
         mock_observer.on_annotate("key", "value")
 
         span.stop()
-        mock_observer.on_stop(error=None)
+        mock_observer.on_stop(exc_info=None)
 
     def test_context(self):
         mock_observer = mock.Mock(spec=SpanObserver)
@@ -84,7 +84,8 @@ class SpanTests(unittest.TestCase):
             with span:
                 raise exc
         self.assertEqual(mock_observer.on_stop.call_count, 1)
-        self.assertEqual(mock_observer.on_stop.call_args, mock.call(error=exc))
+        _, captured_exc, _ = mock_observer.on_stop.call_args[0][0]
+        self.assertEqual(captured_exc, exc)
 
 
 class RootSpanTests(unittest.TestCase):

--- a/tests/unit/diagnostics/metrics_tests.py
+++ b/tests/unit/diagnostics/metrics_tests.py
@@ -5,11 +5,11 @@ from __future__ import unicode_literals
 
 import unittest
 
-from baseplate.core import RootSpan
+from baseplate.core import ServerSpan
 from baseplate.metrics import Client, Batch
 from baseplate.diagnostics.metrics import (
     MetricsBaseplateObserver,
-    MetricsRootSpanObserver,
+    MetricsServerSpanObserver,
     MetricsSpanObserver,
 )
 
@@ -21,28 +21,28 @@ class ObserverTests(unittest.TestCase):
         mock_client = mock.Mock(spec=Client)
         mock_batch = mock_client.batch.return_value
         mock_context = mock.Mock()
-        mock_root_span = mock.Mock(spec=RootSpan)
-        mock_root_span.name = "name"
+        mock_server_span = mock.Mock(spec=ServerSpan)
+        mock_server_span.name = "name"
 
         observer = MetricsBaseplateObserver(mock_client)
-        observer.on_root_span_created(mock_context, mock_root_span)
+        observer.on_server_span_created(mock_context, mock_server_span)
         self.assertEqual(mock_batch.timer.call_args, mock.call("server.name"))
 
         self.assertEqual(mock_context.metrics, mock_batch)
-        self.assertEqual(mock_root_span.register.call_count, 1)
+        self.assertEqual(mock_server_span.register.call_count, 1)
 
 
-class RootSpanObserverTests(unittest.TestCase):
-    def test_root_span_events(self):
+class ServerSpanObserverTests(unittest.TestCase):
+    def test_server_span_events(self):
         mock_batch = mock.Mock(spec=Batch)
         mock_timer = mock_batch.timer.return_value
 
-        observer = MetricsRootSpanObserver(mock_batch, "request_name")
+        observer = MetricsServerSpanObserver(mock_batch, "request_name")
 
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop(exc_info=None)
+        observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
         self.assertEqual(mock_batch.flush.call_count, 1)
 
@@ -59,5 +59,5 @@ class SpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop(exc_info=None)
+        observer.on_finish(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)

--- a/tests/unit/diagnostics/metrics_tests.py
+++ b/tests/unit/diagnostics/metrics_tests.py
@@ -42,7 +42,7 @@ class RootSpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop(error=None)
+        observer.on_stop(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)
         self.assertEqual(mock_batch.flush.call_count, 1)
 
@@ -59,5 +59,5 @@ class SpanObserverTests(unittest.TestCase):
         observer.on_start()
         self.assertEqual(mock_timer.start.call_count, 1)
 
-        observer.on_stop(error=None)
+        observer.on_stop(exc_info=None)
         self.assertEqual(mock_timer.stop.call_count, 1)


### PR DESCRIPTION
The core of this pull request is to rework the tracing / diagnostics APIs in baseplate to match the terminology and functionality of the [OpenTracing](http://opentracing.io) standard. This takes the form of:

* renaming `RootSpan` to `ServerSpan` since there's only one root span in the whole trace
* renaming the `annotate` method on spans `set_tag` to match the standard
* adding a `log` method to spans
* renaming `stop` to `finish` to match the standard
* adding some standard tags to spans in the thrift and pyramid integrations

This is mostly about standardizing and getting ready for actually capturing trace data (in Zipkin) as well as error info in Sentry.

Speaking of Sentry, the other part of this pull request is fixing the way we capture exceptions in spans in two ways: passing the full traceback information to the span observers to allow more introspection, and fixing the pyramid integration's capture of these exceptions.

Note: the Thrift integration doesn't properly capture exceptions at this point. I'm going to pass on fixing that in this pull request because I've got a pull request to switch thrift implementations to thriftpy coming soon (but I didn't want to make this pull request any more complicated).