### PR TITLE
Update cluster_from_config documentation

### DIFF
--- a/baseplate/context/cassandra.py
+++ b/baseplate/context/cassandra.py
@@ -16,7 +16,7 @@ def cluster_from_config(app_config, prefix="cassandra.", **kwargs):
     ``cassandra.contact_points`` etc. The ``prefix`` argument specifies the
     prefix used to filter keys.  Each key is mapped to a corresponding keyword
     argument on the :py:class:`~cassandra.cluster.Cluster` constructor.  Any
-    kwargs sent passed to this function will be passed through to the
+    kwargs given to this function will be passed through to the
     :py:class:`~cassandra.cluster.Cluster` constructor.  If you pass a kwarg
     that is duplicated by ``app_config`` then the value in ``app_config``
     will be passed rather than the one in kwargs.

--- a/baseplate/context/cassandra.py
+++ b/baseplate/context/cassandra.py
@@ -15,7 +15,11 @@ def cluster_from_config(app_config, prefix="cassandra.", **kwargs):
     The keys useful to :py:func:`cluster_from_config` should be prefixed, e.g.
     ``cassandra.contact_points`` etc. The ``prefix`` argument specifies the
     prefix used to filter keys.  Each key is mapped to a corresponding keyword
-    argument on the :py:class:`~cassandra.cluster.Cluster` constructor.
+    argument on the :py:class:`~cassandra.cluster.Cluster` constructor.  Any
+    kwargs sent passed to this function will be passed through to the
+    :py:class:`~cassandra.cluster.Cluster` constructor.  If you pass a kwarg
+    that is duplicated by ``app_config`` then the value in ``app_config``
+    will be passed rather than the one in kwargs.
 
     Supported keys:
 


### PR DESCRIPTION
Update the docstring fro cluster_from_config to indicate that any kwargs will be  forwarded to the Cluster constructor.