### PR TITLE
thrift: Fix binary protocol responses from header protocol server

### DIFF
--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -40,22 +40,18 @@ class GeventServer(StreamServer):
         client = TSocket()
         client.setHandle(client_socket)
 
-        itrans = self.transport_factory.getTransport(client)
-        iprot = self.protocol_factory.getProtocol(itrans)
+        trans = self.transport_factory.getTransport(client)
+        prot = self.protocol_factory.getProtocol(trans)
 
-        otrans = self.transport_factory.getTransport(client)
-        oprot = self.protocol_factory.getProtocol(otrans)
-
-        server_context = TRpcConnectionContext(client, iprot, oprot)
+        server_context = TRpcConnectionContext(client, prot, prot)
 
         try:
             while self.started:
-                self.processor.process(iprot, oprot, server_context)
+                self.processor.process(prot, prot, server_context)
         except TTransportException:
             pass
         finally:
-            itrans.close()
-            otrans.close()
+            trans.close()
 
 
 def make_server(config, listener, app):


### PR DESCRIPTION
THeaderTransport detects the protocol of the client and can accept raw
binary protocol (without headers). It's supposed to then use the same
protocol when responding. Because we were using a different instance of
THeaderTransport for the input and output streams, the detected format
was not being used when responding. This lead to binary protocol clients
hanging as they got invalid data in response. This resolves the issue by
using the same transport and protocol instances in both directions.

:eyeglasses: @dellis23 @krishnan-chandra 