### PR TITLE
debian: Don't install test suite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     url="https://reddit.github.io/baseplate/",
     version="0.14.2",
 
-    packages=find_packages(exclude=["tests"]),
+    packages=find_packages(exclude=["tests", "tests.*"]),
 
     install_requires=install_requires,
     extras_require=extras_require,


### PR DESCRIPTION
This fixes the find_packages() call so we don't install the test suite
as a top-level "tests" package which is pretty messy.

:eyeglasses: @dellis23 @ckwang8128 