### PR TITLE
Use kwargs in call to execute_async

### DIFF
--- a/baseplate/context/cassandra.py
+++ b/baseplate/context/cassandra.py
@@ -89,7 +89,11 @@ class CassandraSessionAdapter(object):
         span.start()
         # TODO: include custom payload
         span.set_tag("statement", query)
-        future = self.session.execute_async(query, parameters, timeout)
+        future = self.session.execute_async(
+            query,
+            parameters=parameters,
+            timeout=timeout,
+        )
         future.add_callback(_on_execute_complete, span)
         future.add_errback(_on_execute_failed, span)
         return future


### PR DESCRIPTION
Looks like we are setting trace=True in all requests because the third argument in Session.execute_async is `trace` rather than `timeout`:

https://github.com/datastax/python-driver/blob/master/cassandra/cluster.py#L2000
