### PR TITLE
Add basic Zipkin-compatible tracing observer

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -147,6 +147,11 @@ class Baseplate(object):
         from .diagnostics.metrics import MetricsBaseplateObserver
         self.register(MetricsBaseplateObserver(metrics_client))
 
+    def configure_tracing(self, service_name, tracing_endpoint):
+        """Collect and send span information for request tracing."""
+        from .diagnostics.tracing import TraceBaseplateObserver
+        self.register(TraceBaseplateObserver(service_name, tracing_endpoint))
+
     def add_to_context(self, name, context_factory):  # pragma: nocover
         """Add an attribute to each request's context object.
 

--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -1,0 +1,276 @@
+"""Components for processing Baseplate spans for service request tracing."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import calendar
+
+import json
+import logging
+import socket
+import threading
+import time
+from datetime import datetime
+
+import requests
+
+from .._compat import queue
+from ..core import BaseplateObserver, SpanObserver, TraceInfo
+
+
+logger = logging.getLogger(__name__)
+
+
+# Span annotation types
+ANNOTATIONS = {
+    'CLIENT_SEND': 'cs',
+    'CLIENT_RECEIVE': 'cr',
+    'SERVER_SEND': 'ss',
+    'SERVER_RECEIVE': 'sr',
+}
+
+
+def current_epoch_microseconds():
+    """Return current UTC time since epoch in microseconds."""
+    epoch_ts = datetime.utcfromtimestamp(0)
+    return int((datetime.utcnow() - epoch_ts).
+               total_seconds() * 1000 * 1000)
+
+
+class TraceBaseplateObserver(BaseplateObserver):
+    """Distributed tracing observer.
+
+    This observer handles Zipkin-compatible distributed tracing
+    instrumentation for both inbound and outbound requests.
+    Baseplate span-specific tracing observers (TraceSpanObserver
+    and TraceServerSpanObserver) are registered for tracking,
+    serializing, and recording span data.
+
+    :param str service_name: The name for the service this observer
+        is registered to.
+    :param str tracing_endpoint: A 'hostname:port' destination to record
+        span data.
+    :param int max_conns: pool size for remote recorder connections.
+    """
+    def __init__(self, service_name, tracing_endpoint=None,
+                 max_conns=100, max_span_queue=10000):
+        self.service_name = service_name
+
+        if tracing_endpoint:
+            self.recorder = RemoteRecorder(tracing_endpoint,
+                                           max_conns=max_conns,
+                                           max_span_queue=max_span_queue)
+        else:
+            self.recorder = NullRecorder()
+
+    def on_server_span_created(self, context, server_span):
+        observer = TraceServerSpanObserver(self.service_name,
+                                           server_span,
+                                           self.recorder)
+        server_span.register(observer)
+
+
+class TraceSpanObserver(SpanObserver):
+    """Span recording observer for outgoing request child spans.
+
+    This observer implements the client-side span portion of a
+    Zipkin request trace.
+    """
+    def __init__(self, service_name, span, recorder):
+        self.service_name = service_name
+        self.recorder = recorder
+        self.span = span
+        self.start = None
+        self.end = None
+        self.elapsed = None
+        self.binary_annotations = []
+        super(TraceSpanObserver, self).__init__()
+
+    def on_start(self):
+        self.start = current_epoch_microseconds()
+        self.client_send = self.start
+
+    def on_finish(self, exc_info):
+        self.end = current_epoch_microseconds()
+        self.elapsed = self.end - self.start
+        self.record()
+
+    def _create_time_annotation(self, annotation_type, timestamp):
+        """Create Zipkin-compatible Annotation for a span.
+
+        This should be used for generating span annotations with a time component,
+        e.g. the core "cs", "sr", "ss", and "sr" Zipkin Annotations
+        """
+        endpoint_info = {
+            'serviceName': self.service_name,
+            'ipv4': socket.gethostbyname(socket.gethostname()),
+        }
+        return {
+            'endpoint': endpoint_info,
+            'timestamp': timestamp,
+            'value': annotation_type,
+        }
+
+    def _create_binary_annotation(self, ):
+        """Create Zipkin-compatible BinaryAnnotation for a span.
+
+        This should be used for generating span annotations that
+        do not have a time component, e.g. URI, arbitrary request tags
+        """
+        # TODO: Implement.
+        raise NotImplementedError
+
+    def _to_span_obj(self, annotations, binary_annotations):
+        span = {
+            "traceId": self.span.trace_id,
+            "name": self.span.name,
+            "id": self.span.id,
+            "timestamp": self.start,
+            "duration": self.elapsed,
+            "annotations": annotations,
+            "binary_annotations": binary_annotations,
+        }
+
+        span['parentId'] = self.span.parent_id or 0
+        return span
+
+    def _serialize(self):
+        """Serialize span information into Zipkin-accepted format."""
+        annotations = []
+
+        annotations.append(
+            self._create_time_annotation(
+                ANNOTATIONS['CLIENT_RECEIVE'],
+                self.start,
+            )
+        )
+
+        annotations.append(
+            self._create_time_annotation(
+                ANNOTATIONS['CLIENT_SEND'],
+                self.end,
+            )
+        )
+
+        return self._to_span_obj(annotations, self.binary_annotations)
+
+    def record(self):
+        """Record serialized span."""
+        serialized = self._serialize()
+        self.recorder.send(serialized)
+
+
+class TraceServerSpanObserver(TraceSpanObserver):
+    """Span recording observer for incoming request spans.
+
+    This observer implements the server-side span portion of a
+    Zipkin request trace
+    """
+
+    def __init__(self, service_name, span, recorder):
+        self.service_name = service_name
+        self.span = span
+        self.recorder = recorder
+        super(TraceServerSpanObserver, self).__init__(service_name,
+                                                      span,
+                                                      recorder)
+
+    def on_start(self):
+        self.start = current_epoch_microseconds()
+
+    def on_child_span_created(self, child_span):
+        child_span_observer = TraceSpanObserver(self.recorder)
+        child_span.register(TraceSpanObserver(self.recorder))
+
+    def on_finish(self, exc_info):
+        self.end = current_epoch_microseconds()
+        self.elapsed = self.end - self.start
+        self.record()
+
+    def _serialize(self):
+        """Serialize span information into Zipkin-accepted format."""
+        annotations = []
+
+        annotations.append(
+            self._create_time_annotation(
+                ANNOTATIONS['SERVER_RECEIVE'],
+                self.start,
+            )
+        )
+        annotations.append(
+            self._create_time_annotation(
+                ANNOTATIONS['SERVER_SEND'],
+                self.end,
+            )
+        )
+
+        return self._to_span_obj(annotations, [])
+
+
+class NullRecorder(object):
+    def __init__(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def send(self, span):
+        """Write a set of spans to debug log."""
+        self.logger.debug("Span recording for trace_id=%s: %s",
+                          span['traceId'],
+                          span)
+
+
+class RemoteRecorder(object):
+    """Interface for recording spans to a remote collector.
+
+    The RemoteRecorder adds spans to an in-memory Queue for a background
+    thread worker to process. It currently does not shut down gracefully -
+    in the event of parent process exit, any remaining spans will be discarded.
+    """
+    def __init__(self, endpoint, max_conns, max_queue_size=10000):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+        adapter = requests.adapters.HTTPAdapter(pool_connections=max_conns,
+                                                pool_maxsize=max_conns)
+        self.session = requests.Session()
+        self.session.mount('http://', adapter)
+        self.endpoint = "http://%s/api/v1/spans" % endpoint
+
+        self.span_queue = queue.Queue(maxsize=max_queue_size)
+        self.flush_worker = None
+        self.flush_worker = threading.Thread(target=self._flush_spans)
+        self.flush_worker.name = "span remote recorder"
+        self.flush_worker.daemon = True
+        self.flush_worker.start()
+
+    def _flush_spans(self):
+        """Send a set of spans to remote collector.
+
+        This reads a batch of at most 10 spans off the recorder queue
+        and sends them to a remote recording endpoint. If the queue
+        empties while being processed before reaching 10 spans, we flush
+        immediately.
+        """
+        while True:
+            spans = []
+            try:
+                while len(spans) < 10:
+                    spans.append(self.span_queue.get_nowait())
+            except queue.Empty:
+                pass
+            finally:
+                if spans:
+                    recording_req = requests.Request(
+                        'POST', self.endpoint,
+                        json=spans,
+                        headers={
+                            'Content-Type': 'application/json',
+                        }).prepare()
+                    self.session.send(recording_req, timeout=2)
+                else:
+                    time.sleep(0.1)
+
+    def send(self, span):
+        try:
+            self.span_queue.put_nowait(span)
+        except Exception as e:
+            self.logger.error("Failed adding span to recording queue: %s", e)

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -137,6 +137,7 @@ your application's :py:class:`~baseplate.core.Baseplate` object.
 
 - Logging: :py:meth:`~baseplate.core.Baseplate.configure_logging`
 - Metrics (statsd): :py:meth:`~baseplate.core.Baseplate.configure_metrics`
+- Tracing (Zipkin): :py:meth:`~baseplate.core.Baseplate.configure_tracing`
 
 Additionally, Baseplate provides helpers which can be attached to the
 :term:`context object` in requests. These helpers make the passing of trace

--- a/docs/baseplate/diagnostics/index.rst
+++ b/docs/baseplate/diagnostics/index.rst
@@ -15,3 +15,5 @@ the request. Under the hood, the context factories
 .. autoclass:: baseplate.diagnostics.logging.LoggingBaseplateObserver
 
 .. autoclass:: baseplate.diagnostics.metrics.MetricsBaseplateObserver
+
+.. autoclass:: baseplate.diagnostics.tracing.TraceBaseplateObserver

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -30,3 +30,4 @@ sysctls
 walkthrough
 Interana
 Enum
+Zipkin

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -1,0 +1,73 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+import webtest
+
+from baseplate import Baseplate
+from baseplate.diagnostics.tracing import (
+    TraceBaseplateObserver,
+    TraceServerSpanObserver,
+    TraceSpanObserver,
+    NullRecorder,
+    RemoteRecorder,
+)
+
+try:
+    from baseplate.integration.pyramid import BaseplateConfigurator
+    from pyramid.config import Configurator
+    from pyramid.request import Request
+except ImportError:
+    raise unittest.SkipTest("pyramid is not installed")
+
+from .. import mock
+
+
+class TestException(Exception):
+    pass
+
+
+def example_application(request):
+    if "error" in request.params:
+        raise TestException("this is a test")
+    return {"test": "success"}
+
+
+class TracingTests(unittest.TestCase):
+
+    def _register_mock(self, context, server_span):
+        server_span_observer = TraceServerSpanObserver('test-service', server_span,
+                                                       NullRecorder())
+        server_span.register(server_span_observer)
+        self.server_span_observer = server_span_observer
+
+    def setUp(self):
+        configurator = Configurator()
+        configurator.add_route("example", "/example", request_method="GET")
+        configurator.add_view(
+            example_application, route_name="example", renderer="json")
+
+        self.observer = TraceBaseplateObserver('test-service')
+
+        self.baseplate = Baseplate()
+        self.baseplate.register(self.observer)
+
+        self.baseplate_configurator = BaseplateConfigurator(
+            self.baseplate,
+            trust_trace_headers=True,
+        )
+        configurator.include(self.baseplate_configurator.includeme)
+        app = configurator.make_wsgi_app()
+        self.test_app = webtest.TestApp(app)
+
+    def test_trace_on_inbound_request(self):
+        with mock.patch.object(TraceBaseplateObserver, 'on_server_span_created',
+                               side_effect=self._register_mock) as mocked:
+
+            self.test_app.get('/example')
+            span = self.server_span_observer._serialize()
+            self.assertEqual(span['name'], 'example')
+            self.assertEqual(len(span['annotations']), 2)
+            self.assertEqual(span['parentId'], 0)

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -1,0 +1,136 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from baseplate.core import Span, ServerSpan
+from baseplate.diagnostics.tracing import (
+    TraceBaseplateObserver,
+    TraceServerSpanObserver,
+    TraceSpanObserver,
+    RemoteRecorder,
+    NullRecorder,
+)
+
+from ... import mock
+
+
+class TraceObserverTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_null_recorder_setup(self):
+        baseplate_observer = TraceBaseplateObserver('test-service')
+        self.assertEqual(type(baseplate_observer.recorder), NullRecorder)
+
+    def test_register_server_span_observer(self):
+        baseplate_observer = TraceBaseplateObserver('test-service')
+        context_mock = mock.Mock()
+        span = ServerSpan('test-id', 'test-parent-id', 'test-span-id', 'test')
+        baseplate_observer.on_server_span_created(context_mock, span)
+        self.assertTrue(len(span.observers), 1)
+        self.assertEqual(type(span.observers[0]), TraceServerSpanObserver)
+
+
+class TraceSpanObserverTests(unittest.TestCase):
+    def setUp(self):
+        self.recorder = NullRecorder()
+        self.span = Span('test-id',
+                         'test-parent-id',
+                         'test-span-id',
+                         'test')
+        self.test_span_observer = TraceSpanObserver('test-service',
+                                                    self.span,
+                                                    self.recorder)
+
+    def test_serialize_uses_span_info(self):
+        serialized_span = self.test_span_observer._serialize()
+        self.assertEqual(serialized_span['traceId'], self.span.trace_id)
+        self.assertEqual(serialized_span['name'], self.span.name)
+        self.assertEqual(serialized_span['id'], self.span.id)
+
+    def test_serialize_adds_cs(self):
+        serialized_span = self.test_span_observer._serialize()
+        cs_in_annotation = False
+        for annotation in serialized_span['annotations']:
+            if annotation['value'] == 'cs':
+                cs_in_annotation = True
+        self.assertTrue(cs_in_annotation)
+
+    def test_serialize_adds_cr(self):
+        serialized_span = self.test_span_observer._serialize()
+        cr_in_annotation = False
+        for annotation in serialized_span['annotations']:
+            if annotation['value'] == 'cr':
+                cr_in_annotation = True
+        self.assertTrue(cr_in_annotation)
+
+    def test_on_start_sets_start_timestamp(self):
+        # on-start should set start time
+        self.assertIsNone(self.test_span_observer.start)
+        self.test_span_observer.on_start()
+        self.assertIsNotNone(self.test_span_observer.start)
+
+    def test_on_finish_sets_end_timestamp_and_duration(self):
+        self.assertIsNone(self.test_span_observer.end)
+        self.test_span_observer.on_start()
+        self.test_span_observer.on_finish(None)
+        self.assertIsNotNone(self.test_span_observer.end)
+
+    def test_on_finish_records(self):
+        self.assertIsNone(self.test_span_observer.end)
+        self.test_span_observer.on_start()
+        self.test_span_observer.on_finish(None)
+        self.assertIsNotNone(self.test_span_observer.end)
+
+    def test_to_span_obj_sets_parent_id(self):
+        span_obj = self.test_span_observer._to_span_obj([], [])
+        self.assertEqual(span_obj['parentId'], self.span.parent_id)
+
+    def test_to_span_obj_sets_default_parent_id(self):
+        self.span.parent_id = None
+        span_obj = self.test_span_observer._to_span_obj([], [])
+        self.assertEqual(span_obj['parentId'], 0)
+
+
+class TraceServerSpanObserverTests(unittest.TestCase):
+    def setUp(self):
+        self.recorder = NullRecorder()
+        self.span = ServerSpan('test-id',
+                               'test-parent-id',
+                               'test-span-id',
+                               'test')
+        self.test_server_span_observer = TraceServerSpanObserver('test-service',
+                                                                 self.span,
+                                                                 self.recorder)
+
+    def test_server_span_observer_inherits_span_observer(self):
+        # in case of future refactoring
+        self.assertTrue(isinstance(self.test_server_span_observer,
+                                   TraceSpanObserver))
+        self.assertTrue(issubclass(TraceServerSpanObserver,
+                                   TraceSpanObserver))
+
+    def test_serialize_uses_span_info(self):
+        serialized_span = self.test_server_span_observer._serialize()
+        self.assertEqual(serialized_span['traceId'], self.span.trace_id)
+        self.assertEqual(serialized_span['name'], self.span.name)
+        self.assertEqual(serialized_span['id'], self.span.id)
+
+    def test_serialize_adds_ss(self):
+        serialized_span = self.test_server_span_observer._serialize()
+        ss_in_annotation = False
+        for annotation in serialized_span['annotations']:
+            if annotation['value'] == 'ss':
+                ss_in_annotation = True
+        self.assertTrue(ss_in_annotation)
+
+    def test_serialize_adds_sr(self):
+        serialized_span = self.test_server_span_observer._serialize()
+        sr_in_annotation = False
+        for annotation in serialized_span['annotations']:
+            if annotation['value'] == 'sr':
+                sr_in_annotation = True
+        self.assertTrue(sr_in_annotation)


### PR DESCRIPTION
The diagnostics.tracing module adds span recording to Baseplate
via a set of observers for both a request's server span and any
child spans. The observer records spans with the basic annotations
required for simple Zipkin querying and visualization, namely the
client_send, client_receive, server_send, and server_receive
annotations.


TraceSpanObservers set `cs` and `cr` annotations for outgoing request spans, and TraceServerSpanObservers set `sr` and `ss` annotations for inbound requests the service handles.

This first pass does *not* include functionality for adding arbitrary span tags ('binary annotations' in Zipkin language) and is missing some optional endpoint information in the base annotations but both should be pretty straightforward with `on_set_tag` and are coming in followup work. This is mainly for feedback on the core implementation details, e.g. the use and structure of the observers.

:eyeglasses: @spladug  @pacejackson 