### PR TITLE
Add binary annotations and span sampling + flags

### DIFF
--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -98,7 +98,11 @@ class PooledClientProxy(object):
                         prot.trans.set_header("Trace", str(span.trace_id))
                         prot.trans.set_header("Parent", str(span.parent_id))
                         prot.trans.set_header("Span", str(span.id))
-
+                        if span.sampled is not None:
+                            sampled = "1" if span.sampled else "0"
+                            prot.trans.set_header("Sampled", sampled)
+                        if span.flags:
+                            prot.trans.set_header("Flags", str(span.flags))
                         client = self.client_cls(prot)
                         method = getattr(client, name)
                         return method(*args, **kwargs)

--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -115,30 +115,42 @@ class TraceSpanObserver(SpanObserver):
         self.elapsed = self.end - self.start
         self.record()
 
+    def on_set_tag(self, key, value):
+        self.binary_annotations.append(
+            self._create_binary_annotation(key, value),
+        )
+
+    def _endpoint_info(self):
+        return {
+            'serviceName': self.service_name,
+            'ipv4': self.hostname,
+        }
+
     def _create_time_annotation(self, annotation_type, timestamp):
         """Create Zipkin-compatible Annotation for a span.
 
         This should be used for generating span annotations with a time component,
         e.g. the core "cs", "sr", "ss", and "sr" Zipkin Annotations
         """
-        endpoint_info = {
-            'serviceName': self.service_name,
-            'ipv4': self.hostname,
-        }
         return {
-            'endpoint': endpoint_info,
+            'endpoint': self._endpoint_info(),
             'timestamp': timestamp,
             'value': annotation_type,
         }
 
-    def _create_binary_annotation(self, ):
+    def _create_binary_annotation(self, annotation_type, annotation_value):
         """Create Zipkin-compatible BinaryAnnotation for a span.
 
         This should be used for generating span annotations that
         do not have a time component, e.g. URI, arbitrary request tags
         """
-        # TODO: Implement.
-        raise NotImplementedError
+        endpoint_info = self._endpoint_info()
+
+        return {
+            'key': annotation_type,
+            'value': annotation_value,
+            'endpoint': endpoint_info,
+        }
 
     def _to_span_obj(self, annotations, binary_annotations):
         span = {

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -83,10 +83,18 @@ class BaseplateConfigurator(object):
         trace_info = None
         if self.trust_trace_headers:
             try:
+                sampled = request.headers.get("X-Sampled", None)
+                if sampled is not None:
+                    sampled = True if sampled == "1" else False
+                flags = request.headers.get("X-Flags", None)
+                if flags is not None:
+                    flags = int(flags)
                 trace_info = TraceInfo.from_upstream(
                     trace_id=int(request.headers["X-Trace"]),
                     parent_id=int(request.headers["X-Parent"]),
                     span_id=int(request.headers["X-Span"]),
+                    sampled=sampled,
+                    flags=flags,
                 )
             except (KeyError, ValueError):
                 pass

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -31,7 +31,6 @@ class RequestContext(object):
     pass
 
 
-
 # TODO: exceptions in the event handler cause the connection to be abruptly
 # closed with no diagnostics sent to the client. that should be more obvious.
 class BaseplateProcessorEventHandler(TProcessorEventHandler):
@@ -52,10 +51,19 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
         trace_info = None
         headers = server_context.iprot.trans.get_headers()
         try:
+            sampled = headers.get(b"Sampled", None)
+            if sampled is not None:
+                sampled = True if sampled.decode('utf-8') == "1" else False
+            flags = headers.get(b"Flags", None)
+            if flags is not None:
+                flags = int(flags)
+
             trace_info = TraceInfo.from_upstream(
                 trace_id=int(headers[b"Trace"]),
                 parent_id=int(headers[b"Parent"]),
                 span_id=int(headers[b"Span"]),
+                sampled=sampled,
+                flags=flags,
             )
         except (KeyError, ValueError):
             pass

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -31,6 +31,7 @@ class RequestContext(object):
     pass
 
 
+
 # TODO: exceptions in the event handler cause the connection to be abruptly
 # closed with no diagnostics sent to the client. that should be more obvious.
 class BaseplateProcessorEventHandler(TProcessorEventHandler):

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -8,12 +8,16 @@ configurables
 Cookiecutter
 crypto
 Einhorn
+Enum
 gevent
 Gevent
 healthcheck
 hostname
 INI
+Interana
 iterable
+kwarg
+kwargs
 lifecycle
 namespace
 predecided
@@ -27,7 +31,6 @@ serializable
 statsd
 subclassing
 sysctls
+unsampled
 walkthrough
-Interana
-Enum
 Zipkin

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -76,6 +76,8 @@ class ConfiguratorTests(unittest.TestCase):
             "X-Trace": "1234",
             "X-Parent": "2345",
             "X-Span": "3456",
+            "X-Sampled": "1",
+            "X-Flags": "1",
         })
 
         self.assertEqual(self.observer.on_server_span_created.call_count, 1)
@@ -85,6 +87,8 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(server_span.trace_id, 1234)
         self.assertEqual(server_span.parent_id, 2345)
         self.assertEqual(server_span.id, 3456)
+        self.assertEqual(server_span.sampled, True)
+        self.assertEqual(server_span.flags, 1)
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -94,7 +94,6 @@ class ThriftTests(unittest.TestCase):
         self.itrans._readBuffer = StringIO(client_memory_trans.getvalue())
 
         self.processor.process(self.iprot, self.oprot, self.server_context)
-
         self.assertEqual(self.observer.on_server_span_created.call_count, 1)
 
         context, server_span = self.observer.on_server_span_created.call_args[0]

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -37,8 +37,10 @@ class ThriftTests(unittest.TestCase):
 
         self.observer = mock.Mock(spec=BaseplateObserver)
         self.server_observer = mock.Mock(spec=ServerSpanObserver)
+
         def _register_mock(context, server_span):
             server_span.register(self.server_observer)
+
         self.observer.on_server_span_created.side_effect = _register_mock
 
         self.logger = mock.Mock(spec=logging.Logger)
@@ -86,6 +88,8 @@ class ThriftTests(unittest.TestCase):
         client_header_trans.set_header("Trace", "1234")
         client_header_trans.set_header("Parent", "2345")
         client_header_trans.set_header("Span", "3456")
+        client_header_trans.set_header("Sampled", "1")
+        client_header_trans.set_header("Flags", "1")
         client = BaseplateService.Client(client_prot)
         try:
             client.is_healthy()
@@ -100,6 +104,8 @@ class ThriftTests(unittest.TestCase):
         self.assertEqual(server_span.trace_id, 1234)
         self.assertEqual(server_span.parent_id, 2345)
         self.assertEqual(server_span.id, 3456)
+        self.assertTrue(server_span.sampled)
+        self.assertEqual(server_span.flags, 1)
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -81,6 +81,10 @@ class TraceSpanObserverTests(unittest.TestCase):
                 cr_in_annotation = True
         self.assertTrue(cr_in_annotation)
 
+    def test_serialize_adds_binary_annotations(self):
+        serialized_span = self.test_span_observer._serialize()
+        self.assertFalse(serialized_span['binary_annotations'])
+
     def test_on_start_sets_start_timestamp(self):
         # on-start should set start time
         self.assertIsNone(self.test_span_observer.start)
@@ -98,6 +102,20 @@ class TraceSpanObserverTests(unittest.TestCase):
         self.test_span_observer.on_start()
         self.test_span_observer.on_finish(None)
         self.assertIsNotNone(self.test_span_observer.end)
+
+    def test_create_binary_annotation(self):
+        annotation = self.test_span_observer._create_binary_annotation('test-key', 'test-value')
+        self.assertEquals(annotation['key'], 'test-key')
+        self.assertEquals(annotation['value'], 'test-value')
+        self.assertTrue(annotation['endpoint'])
+
+    def test_on_set_tag_adds_binary_annotation(self):
+        self.assertFalse(self.test_span_observer.binary_annotations)
+        self.test_span_observer.on_set_tag('test-key', 'test-value')
+        self.assertTrue(self.test_span_observer.binary_annotations)
+        annotation = self.test_span_observer.binary_annotations[0]
+        self.assertEquals(annotation['key'], 'test-key')
+        self.assertEquals(annotation['value'], 'test-value')
 
     def test_to_span_obj_sets_parent_id(self):
         span_obj = self.test_span_observer._to_span_obj([], [])


### PR DESCRIPTION
This adds two features to Baseplate span handling, split across two commits:

1. Add binary annotation generation for on_set_tag events - This is relatively straightforward.

2. Add passing of sampling information and flags in trace information across spans - This adds handling of two more headers for trace information propagation: 
   * "Sampled": If this value is present, it communicates whether or not a request has already been deemed to be sampled or not upstream. If not present, we calculate it at the handling service based on a defined sampling rate. For requests that are not sampled, either by our choice or the upstream-defined option, we do not remotely record the span in baseplate via the observer. 
   * "Flags": This is a 64-bit integer used as a set of bitflags for feature flagging across a distributed tracing system. Currently the only  defined use is for the setting of a "Debug" flag, which allows a request to bypass sampling and "force" tracing. 

Because these pieces of information need to be passed downstream to child spans and processed at request-handling/span creation by way of header parsing, it made the most sense to add this functionality in the TraceInfo and Span objects themselves (rather than try to isolate in the tracing observer). 

More tests are incoming, but wanted to get immediate feedback on implementation. 

:eyeglasses: @spladug 