### PR TITLE
Synapse file_output integration, config.File, and some cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ virtualenv:
 before_install:
     - sudo add-apt-repository -y ppa:reddit/ppa
     - sudo apt-get update -q
-    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34 pep8 pylint python-redis python-gevent
+    - sudo apt-get install -y python-fbthrift python3-fbthrift fbthrift-compiler python-sphinx python-sphinxcontrib.spelling python-alabaster python-posix-ipc python3-posix-ipc python-enum34 python-flake8 pylint python-redis python-gevent
 
 install:
     - pip install -e ".[pyramid]"

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ install:
 	python3 setup.py install
 
 lint:
-	pep8 --repeat --ignore=E501,E128,E226 --exclude=baseplate/thrift/ baseplate/
+	flake8 baseplate/
 	pylint --errors-only baseplate/
 
 

--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -4,8 +4,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import calendar
-
 import json
 import logging
 import random
@@ -17,7 +15,7 @@ from datetime import datetime
 import requests
 
 from .._compat import queue
-from ..core import BaseplateObserver, SpanObserver, TraceInfo
+from ..core import BaseplateObserver, SpanObserver
 
 
 logger = logging.getLogger(__name__)

--- a/baseplate/events/__init__.py
+++ b/baseplate/events/__init__.py
@@ -21,4 +21,5 @@ __all__ = [
     "EventQueue",
     "EventQueueFullError",
     "EventTooLargeError",
+    "FieldKind",
 ]

--- a/baseplate/random.py
+++ b/baseplate/random.py
@@ -1,0 +1,64 @@
+"""Extensions to the standard library `random` module."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import random
+
+
+class WeightedLottery(object):
+    """A lottery where items can have different chances of selection.
+
+    Items will be picked with chance proportional to their weight relative to
+    the sum of all weights, so the higher the weight, the higher the chance of
+    being picked.
+
+    :param items: A sequence of items to choose from.
+    :param weight_key: A function that takes an
+        item in ``items`` and returns a non-negative integer
+        weight for that item.
+    :raises: :py:exc:`ValueError` if any weights are negative or there are no
+        items.
+
+    .. testsetup::
+
+        import random
+        from baseplate.random import WeightedLottery
+        random.seed(12345)
+
+    An example of usage:
+
+    .. doctest::
+
+        >>> words = ["apple", "banana", "cantelope"]
+        >>> lottery = WeightedLottery(words, weight_key=len)
+        >>> lottery.pick()
+        'banana'
+
+    """
+
+    def __init__(self, items, weight_key):
+        self.tickets = 0
+        self.items_with_weights = []
+
+        for item in items:
+            weight = weight_key(item)
+            if weight < 0:
+                raise ValueError("weight for %r must be non-negative" % item)
+            self.tickets += weight
+            self.items_with_weights.append((item, weight))
+
+        if self.tickets == 0:
+            raise ValueError("at least one item must have weight")
+
+    def pick(self):
+        """Pick a random element from the lottery."""
+        winning_ticket = random.random() * self.tickets
+        current_ticket = 0
+        for item, weight in self.items_with_weights:
+            current_ticket += weight
+            if current_ticket > winning_ticket:
+                return item
+        else:  # pragma: nocover
+            raise RuntimeError("weighted_choice failed unexpectedly")

--- a/baseplate/service_discovery.py
+++ b/baseplate/service_discovery.py
@@ -1,0 +1,141 @@
+"""Integration with Synapse's ``file_output`` service discovery method.
+
+.. note:: Production Baseplate services have Synapse hooked up to a
+    local HAProxy instance which will automatically route connections to
+    services for you if you connect to the correct address/port on
+    localhost. That is the preferred method of connecting to services.
+
+    The contents of this module are useful for inspecting the service
+    inventory directly for cases where a blind TCP connection is
+    insufficient (e.g. to give service addresses to a client, or for
+    topology-aware clients like Cassandra).
+
+A basic example of usage::
+
+    inventory = ServiceInventory("/var/lib/synapse/example.json")
+    backend = inventory.get_backend()
+    print(backend.endpoint.address)
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import collections
+import json
+import logging
+import os
+
+from .config import Endpoint
+from .random import WeightedLottery
+
+
+Backend_ = collections.namedtuple("Backend", "id name endpoint weight")
+
+
+class Backend(Backend_):
+    """A description of a service backend.
+
+    This is a tuple of several values:
+
+    ``id``
+        A unique integer ID identifying the backend.
+
+    ``name``
+        The name of the backend.
+
+    ``endpoint``
+        An :py:class:`~baseplate.config.EndpointConfiguration` object
+        describing the network address of the backend.
+
+    ``weight``
+        An integer weight indicating how much to prefer this backend
+        when choosing whom to connect to.
+
+    """
+    pass
+
+
+def _backend_from_json(d):
+    endpoint = Endpoint("%s:%d" % (d["host"], d["port"]))
+    weight = d["weight"] if d["weight"] is not None else 1
+    return Backend(d["id"], d["name"], endpoint, weight)
+
+
+class NoBackendsAvailableError(Exception):
+    """Raised when no backends are available for this service."""
+    pass
+
+
+class ServiceInventory(object):
+    """The inventory enumerates available backends for a single service.
+
+    :param str filename: The absolute path to the Synapse-generated
+        inventory file in JSON format.
+
+    """
+    def __init__(self, filename):
+        self.filename = filename
+        self.mtime = None
+        self.backends = []
+        self.lottery = None
+
+    def _load_backends(self):
+        logging.debug("Loading backends from %s", self.filename)
+
+        try:
+            with open(self.filename) as f:
+                self.backends = [_backend_from_json(d) for d in json.load(f)]
+                self.lottery = WeightedLottery(
+                    self.backends, weight_key=lambda b: b.weight)
+                self.mtime = os.fstat(f.fileno()).st_mtime
+        except IOError as exc:
+            logging.debug("Failed to read service inventory: %s", exc)
+
+    def get_backends(self):
+        """Return a list of all available backends in the inventory.
+
+        If the inventory file becomes unavailable, the previously seen
+        inventory is returned.
+
+        :rtype: list of :py:class:`Backend` objects
+
+        """
+        if self.mtime is None:
+            # we've not loaded the file yet (or we did but that file
+            # got deleted). load the inventory anew.
+            self._load_backends()
+        else:
+            try:
+                current_mtime = os.path.getmtime(self.filename)
+            except OSError:
+                # we had loaded the inventory, but now the file is
+                # gone. blank out our mtime so we try to fetch every
+                # time, but keep the old list around so we don't go
+                # dark.
+                self.mtime = None
+            else:
+                if self.mtime < current_mtime:
+                    # our copy of the data is stale. reload.
+                    self._load_backends()
+        return self.backends
+
+    def get_backend(self):
+        """Return a randomly chosen backend from the available backends.
+
+        If weights are specified in the inventory, they will be
+        respected when making the random selection.
+
+        :rtype: :py:class:`Backend`
+        :raises: :py:exc:`NoBackendsAvailableError` if the inventory
+            has no available endpoints.
+
+        """
+
+        # refresh as necessary
+        backends = self.get_backends()
+        if not backends:
+            raise NoBackendsAvailableError
+
+        return self.lottery.pick()

--- a/docs/baseplate/config.rst
+++ b/docs/baseplate/config.rst
@@ -21,6 +21,7 @@ make complicated expressions.
 .. autofunction:: Endpoint
 .. autofunction:: Timespan
 .. autofunction:: Base64
+.. autofunction:: File
 .. autofunction:: OneOf
 .. autofunction:: TupleOf
 .. autofunction:: Optional

--- a/docs/baseplate/random.rst
+++ b/docs/baseplate/random.rst
@@ -1,0 +1,7 @@
+baseplate.random
+================
+
+.. automodule:: baseplate.random
+
+.. autoclass:: WeightedLottery
+   :members:

--- a/docs/baseplate/service_discovery.rst
+++ b/docs/baseplate/service_discovery.rst
@@ -1,0 +1,15 @@
+baseplate.service_discovery
+===========================
+
+.. automodule:: baseplate.service_discovery
+
+.. autoclass:: ServiceInventory
+   :members:
+
+.. autoclass:: Backend
+
+
+Exceptions
+----------
+
+.. autoexception:: NoBackendsAvailableError

--- a/docs/config_example.ini
+++ b/docs/config_example.ini
@@ -3,3 +3,4 @@ simple = true
 cards = clubs, spades, diamonds
 nested.once = 1
 nested.really.deep = 3 seconds
+some_file = /var/lib/whatever.txt

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ be used without the framework.
    baseplate.random: Extensions to the standard library's random module <baseplate/random>
    baseplate.retry: Policies for retrying operations <baseplate/retry>
    baseplate.thrift_pool: A Thrift client connection pool <baseplate/thrift_pool>
+   baseplate.service_discovery: Integration with Synapse service discovery <baseplate/service_discovery>
 
 Other
 -----

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,6 +57,7 @@ be used without the framework.
    baseplate.events: Events for the data pipeline <baseplate/events>
    baseplate.message_queue: POSIX IPC Message Queues <baseplate/message_queue>
    baseplate.metrics: Counters and timers for statsd <baseplate/metrics>
+   baseplate.random: Extensions to the standard library's random module <baseplate/random>
    baseplate.retry: Policies for retrying operations <baseplate/retry>
    baseplate.thrift_pool: A Thrift client connection pool <baseplate/thrift_pool>
 

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -1,6 +1,7 @@
 aggregator
 app
 backend
+backends
 backoff
 config
 Config
@@ -19,6 +20,7 @@ iterable
 kwarg
 kwargs
 lifecycle
+localhost
 namespace
 predecided
 pubsub

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,6 @@ class baseplate {
   $packages = [
     'fbthrift-compiler',
     'make',
-    'pep8',
     'pylint',
     'python',
     'python3-cassandra',
@@ -34,6 +33,7 @@ class baseplate {
     'python-dev',
     'python-enum34',
     'python-fbthrift',
+    'python-flake8',
     'python-gevent',
     'python-mock',
     'python-nose',

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,7 @@ with-coverage=1
 cover-package=baseplate
 cover-html=1
 cover-html-dir=build/coverage
+
+[flake8]
+ignore = E501,E128,E226
+exclude = baseplate/thrift/

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -7,17 +7,17 @@ from __future__ import print_function
 
 import unittest
 
-import webtest
-
 from baseplate import Baseplate
 from baseplate.core import BaseplateObserver, ServerSpanObserver
 
 try:
+    import webtest
+
     from baseplate.integration.pyramid import BaseplateConfigurator
     from pyramid.config import Configurator
     from pyramid.request import Request
 except ImportError:
-    raise unittest.SkipTest("pyramid is not installed")
+    raise unittest.SkipTest("pyramid/webtest is not installed")
 
 from .. import mock
 

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -4,8 +4,6 @@ from __future__ import print_function
 
 import unittest
 
-import webtest
-
 from baseplate import Baseplate
 from baseplate.diagnostics.tracing import (
     TraceBaseplateObserver,
@@ -16,11 +14,13 @@ from baseplate.diagnostics.tracing import (
 )
 
 try:
-    from baseplate.integration.pyramid import BaseplateConfigurator
+    import webtest
+
     from pyramid.config import Configurator
-    from pyramid.request import Request
+
+    from baseplate.integration.pyramid import BaseplateConfigurator
 except ImportError:
-    raise unittest.SkipTest("pyramid is not installed")
+    raise unittest.SkipTest("pyramid/webtest is not installed")
 
 from .. import mock
 

--- a/tests/unit/config_tests.py
+++ b/tests/unit/config_tests.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import socket
+import tempfile
 import unittest
 
 from baseplate import config
@@ -92,6 +93,35 @@ class Base64Tests(unittest.TestCase):
     def test_valid(self):
         result = config.Base64("aHVudGVyMg==")
         self.assertEqual(result, b"hunter2")
+
+
+class FileTests(unittest.TestCase):
+    def setUp(self):
+        self.tempfile = tempfile.NamedTemporaryFile()
+        self.tempfile.write(b"test")
+        self.tempfile.flush()
+
+    def tearDown(self):
+        self.tempfile.close()
+
+    def test_no_file(self):
+        file_opener = config.File()
+        with self.assertRaises(ValueError):
+            file_opener("/tmp/does_not_exist")
+
+    def test_read_file(self):
+        file_opener = config.File()
+        the_file = file_opener(self.tempfile.name)
+        self.assertEqual(the_file.read(), "test")
+
+    def test_write_file(self):
+        file_opener = config.File(mode="w")
+        the_file = file_opener(self.tempfile.name)
+        the_file.write("cool")
+        the_file.close()
+
+        with open(self.tempfile.name) as f:
+            self.assertEqual(f.read(), "cool")
 
 
 class TimespanTests(unittest.TestCase):

--- a/tests/unit/random_tests.py
+++ b/tests/unit/random_tests.py
@@ -1,0 +1,68 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import collections
+import unittest
+
+from baseplate import random
+
+from .. import mock
+
+
+class WeightedChoiceTests(unittest.TestCase):
+    def test_empty_list(self):
+        with self.assertRaises(ValueError):
+            random.WeightedLottery([], lambda i: i)
+
+    def test_negative_weight(self):
+        with self.assertRaises(ValueError):
+            random.WeightedLottery(["a"], lambda i: -1)
+
+    @mock.patch("random.random")
+    def test_iterator(self, mock_random):
+        iterator = (n for n in range(10))
+
+        mock_random.return_value = 0.0
+        lottery = random.WeightedLottery(iterator, lambda i: i)
+        choice = lottery.pick()
+        self.assertEqual(choice, 1)
+
+    @mock.patch("random.random")
+    def test_choice(self, mock_random):
+        weight_fn = lambda i: 3 if i == "c" else 1
+        items = [
+            "a", # 1
+            "b", # 1
+            "c", # 3
+            "d", # 1
+        ]
+
+        mock_random.return_value = 0.5
+        lottery = random.WeightedLottery(items, weight_fn)
+        choice = lottery.pick()
+        self.assertEqual(choice, "c")
+
+    def test_distribution(self):
+        weight_fn = lambda i: ord(i)-96
+        items = [
+            "a", # 1
+            "b", # 2
+            "c", # 3
+            "d", # 4
+        ]
+        lottery = random.WeightedLottery(items, weight_fn)
+
+        choices = collections.Counter()
+        for _ in range(10000):
+            choice = lottery.pick()
+            choices[choice] += 1
+
+        # we give a bit of fuzz factor here since we're
+        # allowing true randomness in this test and don't
+        # want spurious failures.
+        self.assertLess(abs(1000 - choices["a"]), 150)
+        self.assertLess(abs(2000 - choices["b"]), 150)
+        self.assertLess(abs(3000 - choices["c"]), 150)
+        self.assertLess(abs(4000 - choices["d"]), 150)

--- a/tests/unit/service_discovery_tests.py
+++ b/tests/unit/service_discovery_tests.py
@@ -1,0 +1,135 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import os
+import tempfile
+import time
+import unittest
+
+from baseplate import service_discovery
+
+
+TEST_INVENTORY_ONE = """\
+[
+    {
+        "haproxy_server_options": null,
+        "host": "10.0.1.2",
+        "id": 205,
+        "labels": null,
+        "name": "i-258fc8b6",
+        "port": 9090,
+        "weight": null
+    }
+]
+"""
+
+TEST_INVENTORY_TWO = """\
+[
+    {
+        "haproxy_server_options": null,
+        "host": "10.0.1.2",
+        "id": 205,
+        "labels": null,
+        "name": "i-258fc8b6",
+        "port": 9090,
+        "weight": 1
+    },
+    {
+        "haproxy_server_options": null,
+        "host": "10.0.1.3",
+        "id": 215,
+        "labels": null,
+        "name": "i-650b6a6b",
+        "port": 9090,
+        "weight": 2
+    },
+    {
+        "haproxy_server_options": null,
+        "host": "10.0.1.4",
+        "id": 216,
+        "labels": null,
+        "name": "i-deadbeef",
+        "port": 9090,
+        "weight": 1
+    }
+]
+"""
+
+
+class ServiceInventoryTests(unittest.TestCase):
+    def setUp(self):
+        self.inventory_filename = tempfile.mktemp()
+
+    def tearDown(self):
+        try:
+            os.unlink(self.inventory_filename)
+        except OSError:
+            pass
+
+    def test_load_backends(self):
+        with open(self.inventory_filename, "w") as f:
+            f.write(TEST_INVENTORY_ONE)
+
+        inventory = service_discovery.ServiceInventory(self.inventory_filename)
+
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 1)
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 1)
+        self.assertEqual(backends[0].id, 205)
+        self.assertEqual(backends[0].name, "i-258fc8b6")
+        self.assertEqual(backends[0].endpoint.address.host, "10.0.1.2")
+        self.assertEqual(backends[0].endpoint.address.port, 9090)
+        self.assertEqual(backends[0].weight, 1)
+
+        with open(self.inventory_filename, "w") as f:
+            f.write(TEST_INVENTORY_TWO)
+
+        # force update the mtime into the future so we don't have to
+        # wait around for the filesystem's minimum resolution
+        os.utime(self.inventory_filename, (time.time(), time.time()))
+
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 3)
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 3)
+
+    def test_file_starts_out_missing_then_appears(self):
+        inventory = service_discovery.ServiceInventory(self.inventory_filename)
+
+        backends = inventory.get_backends()
+        self.assertEqual(backends, [])
+
+        with open(self.inventory_filename, "w") as f:
+            f.write(TEST_INVENTORY_ONE)
+
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 1)
+
+    def test_file_exists_then_goes_missing(self):
+        with open(self.inventory_filename, "w") as f:
+            f.write(TEST_INVENTORY_ONE)
+
+        inventory = service_discovery.ServiceInventory(self.inventory_filename)
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 1)
+
+        os.unlink(self.inventory_filename)
+
+        backends = inventory.get_backends()
+        self.assertEqual(len(backends), 1)
+
+    def test_single_get(self):
+        with open(self.inventory_filename, "w") as f:
+            f.write(TEST_INVENTORY_ONE)
+
+        inventory = service_discovery.ServiceInventory(self.inventory_filename)
+        backend = inventory.get_backend()
+        self.assertEqual(backend.id, 205)
+
+    def test_no_backends_available(self):
+        inventory = service_discovery.ServiceInventory(self.inventory_filename)
+        with self.assertRaises(service_discovery.NoBackendsAvailableError):
+            inventory.get_backend()


### PR DESCRIPTION
(definitely go commit-by-commit on this one. It's not so bad, but the overall diff is unnecessarily daunting)

The core of this pull request is a module that can read and understand synapse-generated JSON service inventories. This is needed for the upcoming websocket auto-discovery stuff (IO-1056) and potentially down the line for things like Cassandra clients.

I intend to replace `r2.lib.utils.weighted_lottery` with the implementation here to further standardize.

The `config.File` parser came up in both authn and thing services, so it felt like a good time to get it in here.

While doing this work, I ran into some issues with tests and some cleanliness issues that pyflakes in my editor caught but `make lint` (and therefore CI) didn't; so I've cleaned those up and switched that lint step over to `flake8` for more thoroughness.
