### PR TITLE
Fix binary annotations field name in tracing request

### DIFF
--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -184,7 +184,7 @@ class TraceSpanObserver(SpanObserver):
             "timestamp": self.start,
             "duration": self.elapsed,
             "annotations": annotations,
-            "binary_annotations": binary_annotations,
+            "binaryAnnotations": binary_annotations,
         }
 
         span['parentId'] = self.span.parent_id or 0

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -165,8 +165,12 @@ class TraceSpanObserverTests(unittest.TestCase):
         self.assertTrue(cr_in_annotation)
 
     def test_serialize_adds_binary_annotations(self):
+        self.test_span_observer.on_set_tag('test-key', 'test-value')
         serialized_span = self.test_span_observer._serialize()
-        self.assertFalse(serialized_span['binary_annotations'])
+        self.assertEqual(len(serialized_span['binaryAnnotations']), 1)
+        annotation = serialized_span['binaryAnnotations'][0]
+        self.assertEqual(annotation['key'], 'test-key')
+        self.assertEqual(annotation['value'], 'test-value')
 
     def test_on_start_sets_start_timestamp(self):
         # on-start should set start time
@@ -304,7 +308,7 @@ class RemoteRecorderTests(unittest.TestCase):
             "timestamp": 0,
             "duration": 0,
             "annotations": [],
-            "binary_annotations": [],
+            "binaryAnnotations": [],
         }
         func_mock = mock.Mock()
         with mock.patch.object(recorder.session,


### PR DESCRIPTION
binary annotations aren't being properly recorded because the field name in the tracing API request is wrong. See http://zipkin.io/pages/data_model.html for the binary annotations key `binaryAnnotations`

:eyeglasses: @bsimpson63 