### PR TITLE
Add support for local spans in tracing

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -27,7 +27,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from ..core import BaseplateObserver
+from ..core import (
+    BaseplateObserver,
+    LocalSpan,
+)
 
 
 class ContextFactory(object):
@@ -53,3 +56,8 @@ class ContextObserver(BaseplateObserver):
     def on_server_span_created(self, context, server_span):
         context_attr = self.context_factory.make_object_for_context(self.name, server_span)
         setattr(context, self.name, context_attr)
+
+    def on_child_span_created(self, child_span):
+        if isinstance(child_span, LocalSpan):
+            context_attr = self.context_factory.make_object_for_context(self.name, child_span)
+            setattr(child_span.context, self.name, context_attr)

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -3,7 +3,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from ..core import BaseplateObserver, SpanObserver
+from ..core import (
+    BaseplateObserver,
+    LocalSpan,
+    SpanObserver,
+)
 
 
 class MetricsBaseplateObserver(BaseplateObserver):
@@ -45,7 +49,10 @@ class MetricsSpanObserver(SpanObserver):
 
 class MetricsServerSpanObserver(MetricsSpanObserver):
     def on_child_span_created(self, span):  # pragma: nocover
-        observer = MetricsSpanObserver(self.batch, "clients." + span.name)
+        if isinstance(span, LocalSpan):
+            observer = MetricsSpanObserver(self.batch, "clients." + span.name)
+        else:
+            observer = MetricsSpanObserver(self.batch, span.component_name + "." + span.name)
         span.register(observer)
 
     def on_finish(self, exc_info):

--- a/baseplate/integration/__init__.py
+++ b/baseplate/integration/__init__.py
@@ -4,3 +4,7 @@ This package contains modules which integrate Baseplate with common
 application frameworks.
 
 """
+from .wrapped_context import WrappedRequestContext
+__all__ = [
+    "WrappedRequestContext",
+]

--- a/baseplate/integration/wrapped_context.py
+++ b/baseplate/integration/wrapped_context.py
@@ -1,0 +1,21 @@
+import logging
+
+
+class WrappedRequestContext(object):
+    def __init__(self, context, trace=None):
+        self.__dict__['_context'] = context
+        self.__dict__['logger'] = logging.getLogger(self.__class__.__name__)
+
+    def __getattr__(self, attr):
+        return getattr(self._context, attr)
+
+    def __setattr__(self, attr, value):
+        if attr in self._context.__dict__:
+            self._context.__setattr__(attr, value)
+        else:
+            self.logger.debug("Assigning new attr=%s to wrapped request context.")
+            super(WrappedRequestContext, self).__setattr__(attr, value)
+
+    def clone(self):
+        new_wrapped_context = WrappedRequestContext(self._context)
+        return new_wrapped_context

--- a/tests/integration/sqlalchemy_tests.py
+++ b/tests/integration/sqlalchemy_tests.py
@@ -34,8 +34,8 @@ class SQLAlchemyTests(unittest.TestCase):
         self.factory = SQLAlchemySessionContextFactory(self.engine)
 
     def test_session(self):
-        server_span = mock.Mock(autospec=ServerSpan)
-        span = mock.Mock(autospec=Span)
+        server_span = mock.Mock(spec=ServerSpan)
+        span = mock.Mock(spec=Span)
         span.id = 1234
         span.trace_id = 2345
         server_span.make_child.return_value = span

--- a/tests/unit/context/tests.py
+++ b/tests/unit/context/tests.py
@@ -6,7 +6,10 @@ from __future__ import unicode_literals
 import unittest
 
 from baseplate.context import ContextFactory, ContextObserver
-from baseplate.core import Span
+from baseplate.core import (
+    LocalSpan,
+    Span,
+)
 
 from ... import mock
 
@@ -19,6 +22,18 @@ class ContextObserverTests(unittest.TestCase):
 
         observer = ContextObserver("some_attribute", mock_factory)
         observer.on_server_span_created(mock_context, mock_span)
+
+        self.assertEqual(mock_context.some_attribute,
+            mock_factory.make_object_for_context.return_value)
+
+    def test_add_to_context_local(self):
+        mock_factory = mock.Mock(spec=ContextFactory)
+        mock_context = mock.Mock()
+        mock_local_span = mock.Mock(spec=LocalSpan)
+        mock_local_span.component_name = 'test_component'
+        mock_local_span.context = mock_context
+        observer = ContextObserver("some_attribute", mock_factory)
+        observer.on_child_span_created(mock_local_span)
 
         self.assertEqual(mock_context.some_attribute,
             mock_factory.make_object_for_context.return_value)

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -14,8 +14,21 @@ from baseplate.core import (
     SpanObserver,
     TraceInfo,
 )
+from baseplate.integration import WrappedRequestContext
 
 from .. import mock
+
+
+def make_test_server_span(context=None):
+    if not context:
+        context = mock.Mock()
+    return ServerSpan(1, 2, 3, None, 0, "name", context)
+
+
+def make_test_span(context=None):
+    if not context:
+        context = mock.Mock()
+    return Span(1, 2, 3, None, 0, "name", context)
 
 
 class BaseplateTests(unittest.TestCase):
@@ -30,7 +43,7 @@ class BaseplateTests(unittest.TestCase):
         self.assertEqual(baseplate.observers, [mock_observer])
         self.assertEqual(mock_observer.on_server_span_created.call_count, 1)
         self.assertEqual(mock_observer.on_server_span_created.call_args,
-            mock.call(mock_context, server_span))
+            mock.call(server_span.context, server_span))
 
     def test_null_server_observer(self):
         mock_context = mock.Mock()
@@ -48,7 +61,7 @@ class SpanTests(unittest.TestCase):
     def test_events(self):
         mock_observer = mock.Mock(spec=SpanObserver)
 
-        span = Span(1, 2, 3, None, 0, "name")
+        span = make_test_span()
         span.register(mock_observer)
 
         span.start()
@@ -66,7 +79,7 @@ class SpanTests(unittest.TestCase):
     def test_context(self):
         mock_observer = mock.Mock(spec=SpanObserver)
 
-        span = Span(1, 2, 3, None, 0, "name")
+        span = make_test_span()
         span.register(mock_observer)
 
         with span:
@@ -76,7 +89,8 @@ class SpanTests(unittest.TestCase):
     def test_context_with_exception(self):
         mock_observer = mock.Mock(spec=SpanObserver)
 
-        span = Span(1, 2, 3, None, 0, "name")
+        #span = Span(1, 2, 3, None, 0, "name")
+        span = make_test_span()
         span.register(mock_observer)
 
         class TestException(Exception):
@@ -97,8 +111,9 @@ class ServerSpanTests(unittest.TestCase):
         mock_getrandbits.return_value = 0xCAFE
 
         mock_observer = mock.Mock(spec=ServerSpanObserver)
+        mock_context = mock.Mock()
 
-        server_span = ServerSpan("trace", "parent", "id", None, 0, "name")
+        server_span = ServerSpan("trace", "parent", "id", None, 0, "name", mock_context)
         server_span.register(mock_observer)
         child_span = server_span.make_child("child_name")
 
@@ -114,11 +129,47 @@ class ServerSpanTests(unittest.TestCase):
         mock_observer = mock.Mock(spec=ServerSpanObserver)
         mock_observer.on_child_span_created.return_value = None
 
-        server_span = ServerSpan("trace", "parent", "id", None, 0, "name")
+        server_span = make_test_server_span()
+        #server_span = ServerSpan("trace", "parent", "id", None, 0, "name")
         server_span.register(mock_observer)
         child_span = server_span.make_child("child_name")
 
         self.assertEqual(child_span.observers, [])
+
+    @mock.patch("random.getrandbits", autospec=True)
+    def test_make_local_span(self, mock_getrandbits):
+        mock_getrandbits.return_value = 0xCAFE
+        mock_observer = mock.Mock(spec=ServerSpanObserver)
+        mock_context = mock.Mock()
+        mock_cloned_context = mock.Mock(spec=WrappedRequestContext)
+        mock_context.clone.return_value = mock_cloned_context
+
+        server_span = ServerSpan("trace", "parent", "id", None, 0, "name", mock_context)
+        server_span.register(mock_observer)
+        local_span = server_span.make_child("test_op", local=True,
+                                            component_name="test_component")
+
+        self.assertEqual(local_span.name, "test_op")
+        self.assertEqual(local_span.id, 0xCAFE)
+        self.assertEqual(local_span.trace_id, "trace")
+        self.assertEqual(local_span.parent_id, "id")
+        self.assertEqual(mock_observer.on_child_span_created.call_count, 1)
+        self.assertEqual(mock_observer.on_child_span_created.call_args,
+                         mock.call(local_span))
+
+    @mock.patch("random.getrandbits", autospec=True)
+    def test_make_local_span_copies_context(self, mock_getrandbits):
+        mock_getrandbits.return_value = 0xCAFE
+        mock_observer = mock.Mock(spec=ServerSpanObserver)
+        mock_context = mock.Mock()
+        mock_cloned_context = mock.Mock(spec=WrappedRequestContext)
+        mock_context.clone.return_value = mock_cloned_context
+
+        server_span = ServerSpan("trace", "parent", "id", None, 0, "name", mock_context)
+        server_span.register(mock_observer)
+        local_span = server_span.make_child("test_op", local=True,
+                                                           component_name="test_component")
+        self.assertNotEqual(local_span.context, mock_context)
 
 class TraceInfoTests(unittest.TestCase):
 


### PR DESCRIPTION
This adds baseplate support for tracing local in-request spans. It adheres to the "spec" outlined in the following:

https://github.com/openzipkin/zipkin/issues/808
https://github.com/openzipkin/zipkin/pull/821

This interface is intended to be able to generate local spans in various contexts from the main server span. The differences in serialization, use case, and explicit annotations (or lack thereof) were enough for me to lean towards making a new observer and API to specifically handle local spans. This allows us the freedom to customize Baseplate local spans as we see fit moving forward, e.g. force all local spans to carry certain tags, etc. 
