### PR TITLE
Force string coercion for binary annotation values

### DIFF
--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -140,6 +140,10 @@ class TraceSpanObserver(SpanObserver):
         self.record()
 
     def on_set_tag(self, key, value):
+        """Translate set tags to tracing binary annotations.
+
+        Number-type values are coerced to strings.
+        """
         self.binary_annotations.append(
             self._create_binary_annotation(key, value),
         )
@@ -169,6 +173,10 @@ class TraceSpanObserver(SpanObserver):
         do not have a time component, e.g. URI, arbitrary request tags
         """
         endpoint_info = self._endpoint_info()
+
+        # Annotation values must be bool or str type.
+        if type(annotation_value) not in (bool, str):
+            annotation_value = str(annotation_value)
 
         return {
             'key': annotation_type,

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -198,6 +198,14 @@ class TraceSpanObserverTests(unittest.TestCase):
         self.assertEquals(annotation['value'], 'test-value')
         self.assertTrue(annotation['endpoint'])
 
+    def test_create_binary_annotation_coerces_string(self):
+        annotation = self.test_span_observer._create_binary_annotation(
+            'test-key', 1
+        )
+        self.assertEquals(annotation['key'], 'test-key')
+        self.assertEquals(annotation['value'], '1')
+        self.assertTrue(annotation['endpoint'])
+
     def test_on_set_tag_adds_binary_annotation(self):
         self.assertFalse(self.test_span_observer.binary_annotations)
         self.test_span_observer.on_set_tag('test-key', 'test-value')


### PR DESCRIPTION
Zipkin doesn't like non-string/boolean values for binary annotations, per 
https://github.com/openzipkin/zipkin/issues/1372
and changes introduced in 
https://github.com/openzipkin/zipkin/pull/1269
https://github.com/openzipkin/zipkin/commit/3b8d56ac1b817729517e32c7a3d311b7ceaa2fb7#diff-b603d520f1c771c817602413216dd6c3L191

Based on discussions in the above, the general approach is to coerce numerical values to strings. I'm choosing to do this directly at the baseplate tracing serialization level as a defensive measure. 

:eyeglasses: @bsimpson63  