### PR TITLE
Handle Cassandra Statement queries in statement tag

### DIFF
--- a/baseplate/_compat.py
+++ b/baseplate/_compat.py
@@ -14,11 +14,13 @@ if sys.version_info.major == 3:  # pragma: nocover
     import queue
     from io import BytesIO
     range = range
+    string_types = str,
 else:  # pragma: nocover
     import ConfigParser as configparser
     import Queue as queue
     from cStringIO import StringIO as BytesIO
     range = xrange
+    string_types = basestring,
 
 
 __all__ = [
@@ -26,4 +28,5 @@ __all__ = [
     "queue",
     "BytesIO",
     "range",
+    "string_types",
 ]


### PR DESCRIPTION
Currently we get errors like this when you use a Statement class rather than a string for the query and you have tracing enabled:

```
TypeError: <SimpleStatement query="SELECT * FROM table_name", consistency=Not Set> is not JSON serializable
```