### PR TITLE
tracing: Optionally disable trace logging

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -164,7 +164,8 @@ class Baseplate(object):
                           max_span_queue_size=50000,
                           num_span_workers=5,
                           span_batch_interval=0.5,
-                          sample_rate=0.1):
+                          sample_rate=0.1,
+                          log_if_unconfigured=True):
         """Collect and send span information for request tracing.
 
         :param str service_name: The name for the service this observer
@@ -187,6 +188,7 @@ class Baseplate(object):
                 num_span_workers=num_span_workers,
                 span_batch_interval=span_batch_interval,
                 sample_rate=sample_rate,
+                log_if_unconfigured=log_if_unconfigured,
             )
         )
 

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -177,6 +177,8 @@ class Baseplate(object):
         :param int num_span_workers: number of worker threads for span processing.
         :param float span_batch_interval: wait time for span processing in seconds.
         :param float sample_rate: percentage of unsampled requests to record traces for.
+        :param bool log_if_unconfigured: flag to write traces to logger if no
+            tracing_endpoint is specified.
         """
         from .diagnostics.tracing import TraceBaseplateObserver
         self.register(

--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -327,6 +327,7 @@ class BaseBatchRecorder(object):
 
 
 class LoggingRecorder(BaseBatchRecorder):
+    """Interface for recording spans to the debug log."""
     def __init__(self, max_queue_size=50000,
                  num_workers=5,
                  max_span_batch=100,
@@ -345,6 +346,7 @@ class LoggingRecorder(BaseBatchRecorder):
 
 
 class NullRecorder(BaseBatchRecorder):
+    """Noop recorder."""
     def __init__(self, max_queue_size=50000,
                  num_workers=5,
                  max_span_batch=100,

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -14,6 +14,7 @@ from baseplate.diagnostics.tracing import (
     TraceSpanObserver,
     RemoteRecorder,
     NullRecorder,
+    LoggingRecorder,
 )
 
 from ... import mock
@@ -24,8 +25,15 @@ class TraceObserverTests(unittest.TestCase):
         pass
 
     def test_null_recorder_setup(self):
-        baseplate_observer = TraceBaseplateObserver('test-service')
+        baseplate_observer = TraceBaseplateObserver(
+            'test-service',
+            log_if_unconfigured=False,
+        )
         self.assertEqual(type(baseplate_observer.recorder), NullRecorder)
+
+    def test_logging_recorder_setup(self):
+        baseplate_observer = TraceBaseplateObserver('test-service')
+        self.assertEqual(type(baseplate_observer.recorder), LoggingRecorder)
 
     def test_sets_hostname(self):
         baseplate_observer = TraceBaseplateObserver('test-service')


### PR DESCRIPTION
Rename NullRecorder to LoggingRecorder and make it a noop recorder.
LoggingRecorder is used by default when no tracing endpoint is
specified and will write trace details to the logger.

On dev installs of r2 there's no tracing endpoint specified so the application logs are dominated by the traces. This change will let services (or r2) decide whether to log traces when calling `configure_tracing()`.

👓 @ckwang8128 @spladug 