### PR TITLE
Move on_child_span_created to SpanObserver

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -49,20 +49,21 @@ class SpanObserver(object):  # pragma: nocover
         """
         pass
 
-
-class ServerSpanObserver(SpanObserver):
-    """Interface for an observer that watches the server span."""
-
     def on_child_span_created(self, span):  # pragma: nocover
         """Called when a child span is created.
 
-        :py:class:`ServerSpan` objects call this when a new child span is
+        :py:class:`SpanObserver` objects call this when a new child span is
         created.
 
         :param baseplate.core.Span span: The new child span.
 
         """
         pass
+
+
+class ServerSpanObserver(SpanObserver):
+    """Interface for an observer that watches the server span."""
+    pass
 
 
 _TraceInfo = collections.namedtuple("_TraceInfo",


### PR DESCRIPTION
Since LocalSpans can make child spans, the SpanObserver
class needs a base implementation of the on_child_span_created
method, which ServerSpanObserver can then inherit.

This directly addresses https://github.com/reddit/baseplate/blob/master/baseplate/context/sqlalchemy.py#L115, where a SpanObserver is attached to a span that could be a ServerSpan which can create children. I wasn't sure if making that a ServerSpanObserver made total sense and this was a change that felt better longer term. 

:eyeglasses: @spladug @bsimpson63 