### PR TITLE
Tracing configuration consolidation

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 from . import config, metrics
 from .core import Baseplate
+from .diagnostics import tracing
 
 
 def make_metrics_client(raw_config):
@@ -35,7 +36,65 @@ def make_metrics_client(raw_config):
     return metrics.make_client(cfg.metrics.namespace, cfg.metrics.endpoint)
 
 
+def make_tracing_client(raw_config, log_if_unconfigured=True):
+    """Configure and return a tracing client.
+
+    This expects one configuration option and can take many optional ones:
+
+    ``tracing.service_name``
+        The name for the service this observer is registered to.
+    ``tracing.endpoint`` (optional)
+        Destination to record span data.
+    ``tracing.max_span_queue_size`` (optional)
+        Span processing queue limit.
+    ``tracing.num_span_workers`` (optional)
+        Number of worker threads for span processing.
+    ``tracing.span_batch_interval`` (optional)
+        Wait time for span processing in seconds.
+    ``tracing.num_conns`` (optional)
+        Pool size for remote recorder connection pool.
+    ``tracing.sample_rate`` (optional)
+        Percentage of unsampled requests to record traces for (e.g. 37%)
+
+    :param dict raw_config: The app configuration which should have settings
+        for the tracing client.
+    :param bool log_if_unconfigured: When the client is not configured, should
+        trace spans be logged or discarded silently?
+    :return: A configured client.
+    :rtype: :py:class:`baseplate.diagnostics.tracing.TracingClient`
+
+    """
+
+    cfg = config.parse_config(raw_config, {
+        "tracing": {
+            "service_name": config.String,
+            "endpoint": config.Optional(config.Endpoint),
+            "max_span_queue_size": config.Optional(
+                config.Integer, default=50000),
+            "num_span_workers": config.Optional(config.Integer, default=5),
+            "span_batch_interval": config.Optional(
+                config.Timespan, default=config.Timespan("500 milliseconds")),
+            "num_conns": config.Optional(config.Integer, default=100),
+            "sample_rate": config.Optional(
+                config.Fallback(config.Percent, config.Float), default=0.1),
+        },
+    })
+
+    # pylint: disable=no-member
+    return tracing.make_client(
+        service_name=cfg.tracing.service_name,
+        tracing_endpoint=cfg.tracing.endpoint,
+        max_span_queue_size=cfg.tracing.max_span_queue_size,
+        num_span_workers=cfg.tracing.num_span_workers,
+        span_batch_interval=cfg.tracing.span_batch_interval.total_seconds(),
+        num_conns=cfg.tracing.num_conns,
+        sample_rate=cfg.tracing.sample_rate,
+        log_if_unconfigured=log_if_unconfigured,
+    )
+
+
 __all__ = [
     "make_metrics_client",
+    "make_tracing_client",
     "Baseplate",
 ]

--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -48,6 +48,7 @@ server, The ``config_parser.items(...)`` step is taken care of for you and
     ...     "some_file": config.File(mode="r"),
     ...     "optional": config.Optional(config.Integer, default=9001),
     ...     "sample_rate": config.Percent,
+    ...     "interval": config.Fallback(config.Timespan, config.Integer),
     ... })
 
     >>> print(cfg.simple)
@@ -65,6 +66,9 @@ server, The ``config_parser.items(...)`` step is taken care of for you and
 
     >>> cfg.sample_rate
     0.371
+
+    >>> print(cfg.interval)
+    0:00:30
 
 .. testcleanup::
 
@@ -309,6 +313,20 @@ def Optional(T, default=None):
         else:
             return default
     return optional
+
+
+def Fallback(T1, T2):
+    """An option of type T1, or if that fails to parse, of type T2.
+
+    This is useful for backwards-compatible configuration changes.
+
+    """
+    def fallback(text):
+        try:
+            return T1(text)
+        except ValueError:
+            return T2(text)
+    return fallback
 
 
 class ConfigNamespace(dict):

--- a/docs/baseplate/config.rst
+++ b/docs/baseplate/config.rst
@@ -26,6 +26,7 @@ make complicated expressions.
 .. autofunction:: OneOf
 .. autofunction:: TupleOf
 .. autofunction:: Optional
+.. autofunction:: Fallback
 
 If you need something custom or fancy for your application, just use a
 callable which takes a string and returns the parsed value or raises

--- a/docs/baseplate/index.rst
+++ b/docs/baseplate/index.rst
@@ -4,3 +4,4 @@ baseplate
 .. automodule:: baseplate
 
 .. autofunction:: make_metrics_client
+.. autofunction:: make_tracing_client

--- a/docs/config_example.ini
+++ b/docs/config_example.ini
@@ -5,3 +5,4 @@ nested.once = 1
 nested.really.deep = 3 seconds
 some_file = /var/lib/whatever.txt
 sample_rate = 37.1%
+interval = 30 seconds

--- a/tests/unit/config_tests.py
+++ b/tests/unit/config_tests.py
@@ -226,6 +226,16 @@ class OptionalTests(unittest.TestCase):
             parser("asdf")
 
 
+class FallbackTests(unittest.TestCase):
+    def test_primary_option_works(self):
+        parser = config.Fallback(config.Percent, config.Float)
+        self.assertAlmostEqual(parser("33%"), .33)
+
+    def test_fallback_option_works(self):
+        parser = config.Fallback(config.Percent, config.Float)
+        self.assertAlmostEqual(parser(".44"), .44)
+
+
 class TestParseConfig(unittest.TestCase):
     def setUp(self):
         self.config = {

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -17,6 +17,7 @@ from baseplate.diagnostics.tracing import (
     RemoteRecorder,
     NullRecorder,
     LoggingRecorder,
+    make_client,
 )
 
 from ... import mock
@@ -27,32 +28,32 @@ class TraceObserverTests(unittest.TestCase):
         self.mock_context = mock.Mock()
 
     def test_null_recorder_setup(self):
-        baseplate_observer = TraceBaseplateObserver(
-            'test-service',
-            log_if_unconfigured=False,
-        )
+        client = make_client("test-service", log_if_unconfigured=False)
+        baseplate_observer = TraceBaseplateObserver(client)
         self.assertEqual(type(baseplate_observer.recorder), NullRecorder)
 
     def test_logging_recorder_setup(self):
-        baseplate_observer = TraceBaseplateObserver('test-service')
+        client = make_client("test-service")
+        baseplate_observer = TraceBaseplateObserver(client)
         self.assertEqual(type(baseplate_observer.recorder), LoggingRecorder)
 
     def test_sets_hostname(self):
-        baseplate_observer = TraceBaseplateObserver('test-service')
+        client = make_client("test-service")
+        baseplate_observer = TraceBaseplateObserver(client)
         self.assertIsNotNone(baseplate_observer.hostname)
 
     def test_remote_recorder_setup(self):
-        baseplate_observer = TraceBaseplateObserver(
-            'test-service',
-            tracing_endpoint=Endpoint("test:1111"),
-        )
+        client = make_client(
+            "test-service", tracing_endpoint=Endpoint("test:1111"))
+        baseplate_observer = TraceBaseplateObserver(client)
         self.assertTrue(
             isinstance(baseplate_observer.recorder,
                        RemoteRecorder)
         )
 
     def test_register_server_span_observer(self):
-        baseplate_observer = TraceBaseplateObserver('test-service')
+        client = make_client("test-service")
+        baseplate_observer = TraceBaseplateObserver(client)
         context_mock = mock.Mock()
         span = ServerSpan('test-id', 'test-parent-id', 'test-span-id',
                           True, 0, 'test', self.mock_context)
@@ -83,8 +84,8 @@ class TraceObserverTests(unittest.TestCase):
         )
 
     def test_should_sample_utilizes_sampled_setting(self):
-        baseplate_observer = TraceBaseplateObserver('test-service',
-                                                    sample_rate=0)
+        client = make_client("test-service", sample_rate=0)
+        baseplate_observer = TraceBaseplateObserver(client)
         span_with_sampled_flag = Span('test-id',
                                       'test-parent',
                                       'test-span-id',
@@ -97,8 +98,8 @@ class TraceObserverTests(unittest.TestCase):
         )
 
     def test_should_sample_utilizes_force_sampling(self):
-        baseplate_observer = TraceBaseplateObserver('test-service',
-                                                    sample_rate=0)
+        client = make_client("test-service", sample_rate=0)
+        baseplate_observer = TraceBaseplateObserver(client)
         span_with_forced = Span('test-id',
                                 'test-parent',
                                 'test-span-id',
@@ -121,8 +122,8 @@ class TraceObserverTests(unittest.TestCase):
         )
 
     def test_should_sample_utilizes_sample_rate(self):
-        baseplate_observer = TraceBaseplateObserver('test-service',
-                                                    sample_rate=1)
+        client = make_client("test-service", sample_rate=1)
+        baseplate_observer = TraceBaseplateObserver(client)
         span = Span('test-id',
                     'test-parent',
                     'test-span-id',
@@ -135,8 +136,8 @@ class TraceObserverTests(unittest.TestCase):
         self.assertFalse(baseplate_observer.should_sample(span))
 
     def test_no_tracing_without_sampling(self):
-        baseplate_observer = TraceBaseplateObserver('test-service',
-                                                    sample_rate=0)
+        client = make_client("test-service", sample_rate=0)
+        baseplate_observer = TraceBaseplateObserver(client)
         context_mock = mock.Mock()
         span = ServerSpan('test-id', 'test-parent-id', 'test-span-id',
                           False, 0, 'test', self.mock_context)

--- a/tests/unit/root_tests.py
+++ b/tests/unit/root_tests.py
@@ -1,0 +1,45 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from baseplate import make_tracing_client
+from baseplate.config import ConfigurationError
+from baseplate.diagnostics.tracing import LoggingRecorder, NullRecorder
+
+
+class TracingClientTests(unittest.TestCase):
+    def test_not_configured_at_all(self):
+        with self.assertRaises(ConfigurationError):
+            make_tracing_client({})
+
+    def test_most_simple_config(self):
+        client = make_tracing_client({
+            "tracing.service_name": "example_name",
+        })
+
+        self.assertEqual(client.service_name, "example_name")
+        self.assertIsInstance(client.recorder, LoggingRecorder)
+
+    def test_most_simple_config_without_logging(self):
+        client = make_tracing_client({
+            "tracing.service_name": "example_name",
+        }, log_if_unconfigured=False)
+
+        self.assertEqual(client.service_name, "example_name")
+        self.assertIsInstance(client.recorder, NullRecorder)
+
+    def test_sample_rate_fallback(self):
+        client = make_tracing_client({
+            "tracing.service_name": "example_name",
+            "tracing.sample_rate": "30%",
+        })
+        self.assertAlmostEqual(client.sample_rate, .3)
+
+        client = make_tracing_client({
+            "tracing.service_name": "example_name",
+            "tracing.sample_rate": ".4",
+        })
+        self.assertAlmostEqual(client.sample_rate, .4)


### PR DESCRIPTION
This changes the tracing configuration to be more like the metrics client and various client library integrations. This should cover IO-1629 as brought up in #79. The way this is done does not require flag-day transition from users of baseplate, but they'll instead start getting a deprecation warning.

Old style application code:

```python
cfg = parse_config(app_config, {
    "tracing": {
        "service_name": config.String,
        "tracing_endpoint": config.Optional(config.Endpoint),
        "sample_rate": config.Optional(config.Float, default=0.1),
    },
})

...

baseplate.configure_tracing(
    cfg.tracing.service_name,
    cfg.tracing.tracing_endpoint,
    sample_rate=cfg.tracing.sample_rate,
)
```

New style application code:

```python
tracing_client = make_tracing_client(app_config)

...

baseplate.configure_tracing(tracing_client)
```

I also took the opportunity to (backwards compatibly) move sampling to the Percentage style and allow all the other config options through from config too.

(Sorry, @ckwang8128, I know you had this ticket but I had a few minutes at the tail end of snoo's day and was trying to fix up issues with the cookiecutter (see: https://github.com/reddit/baseplate-cookiecutter/issues/18) that came up recently)