### PR TITLE
Consistently use RawConfigParser; disable interpolation

### DIFF
--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -22,7 +22,7 @@ server, The ``config_parser.items(...)`` step is taken care of for you and
     from baseplate import config
     from baseplate._compat import configparser
     from tempfile import NamedTemporaryFile
-    config_parser = configparser.ConfigParser()
+    config_parser = configparser.RawConfigParser()
     config_parser.readfp(open("docs/config_example.ini"))
 
     tempfile = NamedTemporaryFile()

--- a/baseplate/events/publisher.py
+++ b/baseplate/events/publisher.py
@@ -160,7 +160,7 @@ def publish_events():
         level = logging.WARNING
     logging.basicConfig(level=level)
 
-    config_parser = configparser.ConfigParser()
+    config_parser = configparser.RawConfigParser()
     config_parser.readfp(args.config_file)
     raw_config = dict(config_parser.items("event-publisher:" + args.queue_name))
     cfg = config.parse_config(raw_config, {

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -56,6 +56,8 @@ Configuration = collections.namedtuple(
 
 
 def read_config(config_file, server_name, app_name):
+    # we use RawConfigParser to reduce surprise caused by interpolation and so
+    # that config.Percent works more naturally (no escaping %).
     parser = configparser.RawConfigParser()
     parser.readfp(config_file)
 

--- a/baseplate/server/__init__.py
+++ b/baseplate/server/__init__.py
@@ -56,7 +56,7 @@ Configuration = collections.namedtuple(
 
 
 def read_config(config_file, server_name, app_name):
-    parser = configparser.SafeConfigParser()
+    parser = configparser.RawConfigParser()
     parser.readfp(config_file)
 
     filename = config_file.name


### PR DESCRIPTION
We're not currently using interpolation anywhere and this frees up the %
character for use in the Percent config parser and reduces suprise.