### PR TITLE
Vault

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -9,9 +9,10 @@ import sys
 from . import config, metrics
 from .core import Baseplate
 from .diagnostics import tracing
+from ._utils import warn_deprecated
 
 
-def make_metrics_client(raw_config):
+def metrics_client_from_config(raw_config):
     """Configure and return a metrics client.
 
     This expects two configuration options:
@@ -39,7 +40,13 @@ def make_metrics_client(raw_config):
     return metrics.make_client(cfg.metrics.namespace, cfg.metrics.endpoint)
 
 
-def make_tracing_client(raw_config, log_if_unconfigured=True):
+def make_metrics_client(raw_config):
+    warn_deprecated("make_metrics_client is deprecated in favor of the more "
+                    "consistently named metrics_client_from_config")
+    return metrics_client_from_config(raw_config)
+
+
+def tracing_client_from_config(raw_config, log_if_unconfigured=True):
     """Configure and return a tracing client.
 
     This expects one configuration option and can take many optional ones:
@@ -94,6 +101,12 @@ def make_tracing_client(raw_config, log_if_unconfigured=True):
         sample_rate=cfg.tracing.sample_rate,
         log_if_unconfigured=log_if_unconfigured,
     )
+
+
+def make_tracing_client(raw_config, log_if_unconfigured=True):
+    warn_deprecated("make_tracing_client is deprecated in favor of the more "
+                    "consistently named tracing_client_from_config")
+    return tracing_client_from_config(raw_config, log_if_unconfigured)
 
 
 def error_reporter_from_config(raw_config, module_name):
@@ -178,8 +191,10 @@ def error_reporter_from_config(raw_config, module_name):
 
 
 __all__ = [
+    "error_reporter_from_config",
     "make_metrics_client",
     "make_tracing_client",
-    "error_reporter_from_config",
+    "metrics_client_from_config",
+    "tracing_client_from_config",
     "Baseplate",
 ]

--- a/baseplate/_compat.py
+++ b/baseplate/_compat.py
@@ -14,6 +14,7 @@ if sys.version_info.major == 3:  # pragma: nocover
     import queue
     from io import BytesIO
     import pickle
+    from urllib.parse import urljoin  # pylint: disable=no-name-in-module
     range = range
     string_types = str,
     long = int
@@ -23,6 +24,7 @@ else:  # pragma: nocover
     import Queue as queue
     import cPickle as pickle
     from cStringIO import StringIO as BytesIO
+    from urlparse import urljoin
     range = xrange
     string_types = basestring,
     long = long
@@ -30,11 +32,12 @@ else:  # pragma: nocover
 
 
 __all__ = [
-    "configparser",
-    "queue",
+    "builtins",
     "BytesIO",
+    "configparser",
+    "pickle",
+    "queue",
     "range",
     "string_types",
-    "pickle",
-    "builtins",
+    "urljoin",
 ]

--- a/baseplate/crypto.py
+++ b/baseplate/crypto.py
@@ -1,5 +1,32 @@
 """Utilities for common cryptographic operations.
 
+.. testsetup::
+
+    import datetime
+    from baseplate.crypto import make_signature, validate_signature
+    from baseplate.secrets import SecretsStore
+
+    secrets = SecretsStore("docs/secrets.json")
+
+.. testcode::
+
+    message = "Hello, world!"
+
+    secret = secrets.get_versioned("some_signing_key")
+    signature = make_signature(
+        secret, message, max_age=datetime.timedelta(days=1))
+
+    try:
+        validate_signature(secret, message, signature)
+    except SignatureError:
+        print("Oh no, it was invalid!")
+    else:
+        print("Message was valid!")
+
+.. testoutput::
+
+    Message was valid!
+
 
 """
 from __future__ import absolute_import
@@ -14,6 +41,9 @@ import hashlib
 import hmac
 import struct
 import time
+
+from baseplate._utils import warn_deprecated
+from baseplate.secrets import VersionedSecret
 
 
 if hasattr(hmac, "compare_digest"):
@@ -92,89 +122,97 @@ class SignatureInfo(_SignatureInfo):
     pass
 
 
+def _compute_digest(secret_value, header, message):
+    payload = header + message.encode("utf8")
+    digest = hmac.new(secret_value, payload, hashlib.sha256).digest()  # pylint: disable=no-member
+    return digest
+
+
+def make_signature(secret, message, max_age):
+    """Return a signature for the given message.
+
+    To ensure that key rotation works automatically, always fetch the secret
+    token from the secret store immediately before use and do not cache / save
+    the token anywhere. The ``current`` version of the secret will be used to
+    sign the token.
+
+    :param baseplate.secrets.VersionedSecret secret: The secret signing key
+        from the secret store.
+    :param str message: The message to sign.
+    :param datetime.timedelta max_age: The amount of time in the future
+        the signature will be valid for.
+    :return: An encoded signature.
+
+    """
+    version = 1
+    expiration = int(time.time() + max_age.total_seconds())
+    header = _HEADER_FORMAT.pack(version, expiration)
+    digest = _compute_digest(secret.current, header, message)
+    return base64.urlsafe_b64encode(header + digest)
+
+
+def validate_signature(secret, message, signature):
+    """Validate and assert a message's signature is correct.
+
+    If the signature is valid, the function will return normally with a
+    :py:class:`SignatureInfo` with some details about the signature.
+    Otherwise, an exception will be raised.
+
+    To ensure that key rotation works automatically, always fetch the secret
+    token from the secret store immediately before use and do not cache / save
+    the token anywhere. All active versions of the secret will be checked when
+    validating the signature.
+
+    :param baseplate.secrets.VersionedSecret secret: The secret signing key
+        from the secret store.
+    :param str message: The message payload to validate.
+    :param str signature: The signature supplied with the message.
+    :raises: :py:exc:`UnreadableSignatureError` The signature is corrupt.
+    :raises: :py:exc:`IncorrectSignatureError` The digest is incorrect.
+    :raises: :py:exc:`ExpiredSignatureError` The signature expired.
+    :rtype: :py:class:`SignatureInfo`
+
+    """
+    try:
+        signature_bytes = base64.urlsafe_b64decode(signature)
+        header = signature_bytes[:_HEADER_FORMAT.size]
+        signature_digest = signature_bytes[_HEADER_FORMAT.size:]
+        version, expiration = _HEADER_FORMAT.unpack(header)
+        if version != 1:
+            raise ValueError
+        if len(signature_digest) != hashlib.sha256().digest_size:  # pylint: disable=no-member
+            raise ValueError
+    except (struct.error, KeyError, binascii.Error, TypeError, ValueError):
+        raise UnreadableSignatureError
+
+    for secret_value in secret.all_versions:
+        digest = _compute_digest(secret_value, header, message)
+        if constant_time_compare(digest, signature_digest):
+            break
+    else:
+        raise IncorrectSignatureError
+
+    if time.time() > expiration:
+        raise ExpiredSignatureError(expiration)
+
+    return SignatureInfo(version, expiration)
+
+
 class MessageSigner(object):
     """Helper which signs messages and validates signatures given a secret.
 
-    .. testsetup::
-
-        import datetime
-        from baseplate.crypto import MessageSigner
-
-    .. testcode::
-
-        message = "Hello, world!"
-
-        signer = MessageSigner(b"supersecret")
-        signature = signer.make_signature(
-            message, max_age=datetime.timedelta(days=1))
-
-        try:
-            signer.validate_signature(message, signature)
-        except SignatureError:
-            print("Oh no, it was invalid!")
-        else:
-            print("Message was valid!")
-
-    .. testoutput::
-
-        Message was valid!
+    This is for backwards compatibility. Use the secret store and proper
+    versioned secrets for new code.
 
     """
     def __init__(self, secret_key):
-        self.secret_key = secret_key
-
-    def _compute_digest(self, header, message):
-        payload = header + message.encode("utf8")
-        digest = hmac.new(self.secret_key, payload, hashlib.sha256).digest()  # pylint: disable=no-member
-        return digest
+        warn_deprecated("MessageSigner is deprecated in favor of the top-level "
+                        "make_signature and validate_signature functions which "
+                        "accept versioned secrets from the secret store.")
+        self.secret = VersionedSecret.from_simple_secret(secret_key)
 
     def make_signature(self, message, max_age):
-        """Return a signature for the given message.
-
-        :param str message: The message to sign.
-        :param datetime.timedelta max_age: The amount of time in the future
-            the signature will be valid for.
-        :return: An encoded signature.
-
-        """
-        version = 1
-        expiration = int(time.time() + max_age.total_seconds())
-        header = _HEADER_FORMAT.pack(version, expiration)
-        digest = self._compute_digest(header, message)
-        return base64.urlsafe_b64encode(header + digest)
+        return make_signature(self.secret, message, max_age)
 
     def validate_signature(self, message, signature):
-        """Validate and assert a message's signature is correct.
-
-        If the signature is valid, the function will return normally with a
-        :py:class:`SignatureInfo` with some details about the signature.
-        Otherwise, an exception will be raised.
-
-        :param str message: The message payload to validate.
-        :param str signature: The signature supplied with the message.
-        :raises: :py:exc:`UnreadableSignatureError` The signature is corrupt.
-        :raises: :py:exc:`IncorrectSignatureError` The digest is incorrect.
-        :raises: :py:exc:`ExpiredSignatureError` The signature expired.
-        :rtype: :py:class:`SignatureInfo`
-
-        """
-        try:
-            signature_bytes = base64.urlsafe_b64decode(signature)
-            header = signature_bytes[:_HEADER_FORMAT.size]
-            signature_digest = signature_bytes[_HEADER_FORMAT.size:]
-            version, expiration = _HEADER_FORMAT.unpack(header)
-            if version != 1:
-                raise ValueError
-            if len(signature_digest) != hashlib.sha256().digest_size:  # pylint: disable=no-member
-                raise ValueError
-        except (struct.error, KeyError, binascii.Error, TypeError, ValueError):
-            raise UnreadableSignatureError
-
-        digest = self._compute_digest(header, message)
-        if not constant_time_compare(digest, signature_digest):
-            raise IncorrectSignatureError
-
-        if time.time() > expiration:
-            raise ExpiredSignatureError(expiration)
-
-        return SignatureInfo(version, expiration)
+        return validate_signature(self.secret, message, signature)

--- a/baseplate/secrets/__init__.py
+++ b/baseplate/secrets/__init__.py
@@ -1,0 +1,23 @@
+"""Secure access to secret tokens stored in Vault."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+from .store import (
+    CorruptSecretError,
+    SecretNotFoundError,
+    SecretsStore,
+    secrets_store_from_config,
+    VersionedSecret,
+)
+
+
+__all__ = [
+    "CorruptSecretError",
+    "SecretNotFoundError",
+    "SecretsStore",
+    "secrets_store_from_config",
+    "VersionedSecret",
+]

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -1,0 +1,280 @@
+"""Daemon that fetches secrets from Vault and writes them to disk.
+
+This daemon looks for configuration in an INI file passed on the command line.
+The file should contain a section looking like:
+
+    [secret-fetcher]
+    vault.url = https://vault.example.com:8200/
+    vault.role = my-server-role
+
+    output.path = /var/local/secrets.json
+    output.owner = www-data
+    output.group = www-data
+    output.mode = 0400
+
+    secrets =
+        secret/one,
+        secret/two,
+        secret/three,
+
+where each secret is a path to look up in Vault. The daemon authenticates with
+Vault as the EC2 server it is running on. Vault can map that context to
+appropriate policies accordingly.
+
+The secrets will be read from Vault and written to output.path as a JSON file
+with the following structure:
+
+    {
+        "secrets": {
+            "secret/one": {...},
+            "secret/two": {...},
+            "secret/three": {...}
+        },
+        "vault_token": "9da4241c-3460-11e7-84ac-0e9f9d32522f"
+    }
+
+The vault_token can be used for direct communication with Vault using the
+server's authority. The file will be updated as secrets expire and need to be
+refetched.
+
+The `store` module in this package contains utilities for interacting with this
+file from a running service.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import datetime
+import grp
+import json
+import logging
+import os
+import posixpath
+import pwd
+import time
+
+import requests
+
+from .._compat import configparser, urljoin
+from .. import config
+
+
+logger = logging.getLogger(__name__)
+
+
+NONCE_FILENAME = "/var/local/vault.nonce"
+VAULT_TOKEN_PREFETCH_TIME = datetime.timedelta(seconds=60)
+
+
+def fetch_instance_identity():
+    """Retrieve the instance identity document from the metadata service.
+
+    http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html
+
+    """
+    logger.debug("Fetching identity.")
+    resp = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")
+    resp.raise_for_status()
+    return resp.text
+
+
+def load_nonce():
+    """Load the nonce from disk."""
+    try:
+        logger.debug("Loading nonce.")
+        with open(NONCE_FILENAME, "r") as f:
+            return f.read()
+    except IOError as exc:
+        logger.debug("Nonce not found: %s.", exc)
+        return None
+
+
+def store_nonce(nonce):
+    """Store the nonce to disk securely."""
+    logger.debug("Storing nonce.")
+    fd = os.open(NONCE_FILENAME, os.O_WRONLY | os.O_CREAT, 0o400)
+    with os.fdopen(fd, "w") as f:
+        f.write(nonce)
+
+
+def ttl_to_time(ttl):
+    """Return an absolute expiration time given a TTL."""
+    return datetime.datetime.utcnow() + datetime.timedelta(seconds=ttl)
+
+
+class VaultClientFactory(object):
+    """Factory that makes authenticated clients."""
+    def __init__(self, base_url, role):
+        self.base_url = base_url
+        self.role = role
+        self.session = requests.Session()
+        self.client = None
+
+    def _make_client(self):
+        """Authenticate with Vault and return a client containing that token.
+
+        This authenticates with Vault as a specified role using its AWS EC2
+        auth backend. This involves sending to Vault the AWS-signed instance
+        identity document from the instance metadata API. Vault should have an
+        appropriate role-mapping configured for the server so that appropriate
+        policies can be applied to the returned token. For example, to
+        authenticate any server with the `my-servers-iam-role` IAM Role:
+
+            vault write /auth/aws-ec2/role/my-server-role \
+                bound_iam_arn=arn:aws:iam::12341234:role/my-servers-iam-role \
+                policies=my-servers-policies \
+                max_ttl=4h
+
+        To combat replay attacks where the identity document is snarfed and
+        passed on by an interloper, during first login we store a
+        Vault-generated nonce locally in a protected file. This nonce must be
+        passed back to Vault on all successive login attempts.
+
+        See https://www.vaultproject.io/docs/auth/aws-ec2.html for more info.
+
+        """
+        identity_document = fetch_instance_identity()
+        nonce = load_nonce()
+
+        login_data = {
+            "role": self.role,
+            "pkcs7": identity_document,
+        }
+
+        if nonce:
+            login_data["nonce"] = nonce
+
+        logger.debug("Logging into Vault.")
+        response = self.session.post(
+            urljoin(self.base_url, "/v1/auth/aws-ec2/login"),
+            json=login_data,
+        )
+        response.raise_for_status()
+        response_payload = response.json()
+
+        nonce = response_payload["auth"]["metadata"]["nonce"]
+        store_nonce(nonce)
+
+        return VaultClient(
+            self.session,
+            self.base_url,
+            response_payload["auth"]["client_token"],
+            ttl_to_time(response_payload["auth"]["lease_duration"]),
+        )
+
+    def get_client(self):
+        """Get an authenticated client, reauthenticating if not cached."""
+        if not self.client or self.client.is_about_to_expire:
+            self.client = self._make_client()
+        return self.client
+
+
+class VaultClient(object):
+    """An authenticated vault client.
+
+    Use this as long as is_about_to_expire is False. Once that becomes True,
+    get a new client from the factory.
+
+    """
+    def __init__(self, session, base_url, token, token_expiration):
+        self.session = session
+        self.base_url = base_url
+        self.token = token
+        self.token_expiration = token_expiration
+
+    @property
+    def is_about_to_expire(self):
+        """Is the token near expiration and in need of regeneration?"""
+        expiration = self.token_expiration - VAULT_TOKEN_PREFETCH_TIME
+        return expiration < datetime.datetime.utcnow()
+
+    def get_secret(self, secret_name):
+        """Get the value and expiration time of a named secret."""
+        logger.debug("Fetching secret %r.", secret_name)
+        response = self.session.get(
+            urljoin(self.base_url, posixpath.join("v1", secret_name)),
+            headers={
+                "X-Vault-Token": self.token,
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload["data"], ttl_to_time(payload["lease_duration"])
+
+
+def octal_integer(text):
+    return int(text, base=8)
+
+
+def user_name_to_uid(text):
+    return pwd.getpwnam(text).pw_uid
+
+
+def group_name_to_gid(text):
+    return grp.getgrnam(text).gr_gid
+
+
+def main():
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument("config_file", type=argparse.FileType("r"),
+        help="path to a configuration file")
+    arg_parser.add_argument("--debug", default=False, action="store_true",
+        help="enable debug logging")
+    args = arg_parser.parse_args()
+
+    if args.debug:
+        level = logging.DEBUG
+    else:
+        level = logging.WARNING
+    logging.basicConfig(level=level)
+
+    parser = configparser.RawConfigParser()
+    parser.readfp(args.config_file)
+    fetcher_config = dict(parser.items("secret-fetcher"))
+
+    cfg = config.parse_config(fetcher_config, {
+        "vault": {
+            "url": config.String,
+            "role": config.String,
+        },
+
+        "output": {
+            "path": config.Optional(config.String, default="/var/local/secrets.json"),
+            "owner": config.Optional(user_name_to_uid, default=0),
+            "group": config.Optional(group_name_to_gid, default=0),
+            "mode": config.Optional(octal_integer, default=0o400),
+        },
+
+        "secrets": config.Optional(config.TupleOf(config.String), default=[]),
+    })
+
+    # pylint: disable=no-member
+    client_factory = VaultClientFactory(cfg.vault.url, cfg.vault.role)
+    while True:
+        client = client_factory.get_client()
+
+        secrets = {}
+        soonest_expiration = client.token_expiration
+        for secret_name in cfg.secrets:
+            secrets[secret_name], expiration = client.get_secret(secret_name)
+            soonest_expiration = min(soonest_expiration, expiration)
+
+        with open(cfg.output.path, "w") as f:
+            os.fchown(f.fileno(), cfg.output.owner, cfg.output.group)
+            os.fchmod(f.fileno(), cfg.output.mode)
+
+            json.dump({
+                "vault_token": client.token,
+                "secrets": secrets,
+            }, f, indent=2, sort_keys=True)
+
+        time_til_expiration = soonest_expiration - datetime.datetime.utcnow()
+        time_to_sleep = time_til_expiration - VAULT_TOKEN_PREFETCH_TIME
+        time.sleep(max(int(time_to_sleep.total_seconds()), 1))
+
+
+if __name__ == "__main__":
+    main()

--- a/baseplate/secrets/store.py
+++ b/baseplate/secrets/store.py
@@ -231,8 +231,8 @@ class SecretsStore(ContextFactory):
 
         try:
             current_value = secret_attributes["current"]
-        except KeyError as exc:
-            raise CorruptSecretError(path, "secret does not have %s" % exc)
+        except KeyError:
+            raise CorruptSecretError(path, "secret does not have 'current' value")
 
         encoding = secret_attributes.get("encoding", "identity")
         return VersionedSecret(

--- a/baseplate/secrets/store.py
+++ b/baseplate/secrets/store.py
@@ -1,0 +1,276 @@
+"""Application integration with the secret fetcher daemon."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import base64
+import binascii
+import collections
+import json
+import logging
+import os
+
+from .. import config
+from ..context import ContextFactory
+
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+logger = logging.getLogger(__name__)
+
+
+class SecretNotFoundError(Exception):
+    """Raised when the requested secret is not in the local vault."""
+
+    def __init__(self, name):
+        super(SecretNotFoundError, self).__init__()
+        self.name = name
+
+    def __str__(self):  # pragma: nocover
+        return "secret not found: {!r}".format(self.name)
+
+
+class CorruptSecretError(Exception):
+    """Raised when the requested secret does not match the expected format."""
+
+    def __init__(self, path, message):
+        super(CorruptSecretError, self).__init__()
+        self.path = path
+        self.message = message
+
+    def __str__(self):  # pragma: nocover
+        return "{}: {}".format(self.path, self.message)
+
+
+_VersionedSecret = collections.namedtuple(
+    "VersionedSecret", "previous current next")
+
+
+class VersionedSecret(_VersionedSecret):
+    """A versioned secret.
+
+    Versioned secrets allow for seamless rotation of keys. When using the
+    secret to generate tokens (e.g. signing a message) always use the
+    ``current`` value. When validating tokens, check against all the versions
+    in ``all_versions``. This will allow keys to rotate smoothly even if not
+    done instantly across all users of the secret.
+
+    """
+
+    @property
+    def all_versions(self):
+        """Return an iterator over the available versions of this secret."""
+        yield self.current
+
+        if self.previous is not None:
+            yield self.previous
+
+        if self.next is not None:
+            yield self.next
+
+    @classmethod
+    def from_simple_secret(cls, value):
+        """Make a fake versioned secret from a single value.
+
+        This is a backwards compatibility shim for use with APIs that take
+        versioned secrets. Try to use proper versioned secrets fetched from the
+        secrets store instead.
+
+        """
+        return cls(
+            previous=None,
+            current=value,
+            next=None,
+        )
+
+
+def _decode_secret(path, encoding, value):
+    if encoding == "identity":
+        # encode to bytes for consistency with the base64 path. utf-8 because
+        # that undoes json encoding.
+        return value.encode("utf-8")
+    elif encoding == "base64":
+        try:
+            return base64.b64decode(value)
+        except (TypeError, binascii.Error) as exc:
+            raise CorruptSecretError(path, "unable to decode base64: %s" % exc)
+    else:
+        raise CorruptSecretError(path, "unknown encoding: %r" % encoding)
+
+
+class SecretsStore(ContextFactory):
+    """Access to secret tokens with automatic refresh when changed.
+
+    This local vault allows access to the secrets cached on disk by the fetcher
+    daemon. It will automatically reload the cache when it is changed. Do not
+    cache or store the values returned by this class's methods but rather get
+    them from this class each time you need them. The secrets are served from
+    memory so there's little performance impact to doing so and you will be
+    sure to always have the current version in the face of key rotation etc.
+
+    """
+
+    def __init__(self, path):
+        self._path = path
+        self._mtime = 0
+        self._secrets = None
+        self._vault_token = None
+
+    def _load_if_needed(self):
+        """Load the secrets from disk if expired or modified since last read.
+
+        Expired secrets are always bad, but it's also important to reload if
+        changed because this allows configuration changes of the fetcher daemon
+        to be picked up automatically by running services without being
+        restarted and also makes us less susceptible to race conditions when
+        both are being restarted at the same time.
+
+        """
+        try:
+            secrets_file_updated = self._mtime < os.path.getmtime(self._path)
+        except OSError:
+            secrets_file_updated = False
+
+        if secrets_file_updated:
+            logger.debug("Loading secrets from %s.", self._path)
+
+            with open(self._path) as f:
+                raw_data = json.load(f)
+                mtime = os.fstat(f.fileno()).st_mtime
+
+            self._vault_token = raw_data["vault_token"]
+            self._secrets = raw_data["secrets"]
+            self._mtime = mtime
+
+    def get_vault_token(self):
+        """Return a Vault authentication token.
+
+        The token will have policies attached based on the current EC2 server's
+        Vault role. This is only necessary if talking directly to Vault.
+
+        :rtype: :py:class:`str`
+
+        """
+        self._load_if_needed()
+        return self._vault_token
+
+    def get_raw(self, path):
+        """Return a dictionary of key/value pairs for the given secret path.
+
+        This is the raw representation of the secret in the underlying store.
+
+        :rtype: :py:class:`dict`
+
+        """
+        self._load_if_needed()
+
+        try:
+            return self._secrets[path]
+        except KeyError:
+            raise SecretNotFoundError(path)
+
+    def get_simple(self, path):
+        """Decode and return a simple secret.
+
+        Simple secrets are a convention of key/value pairs in the raw secret
+        payload.  The following keys are significant:
+
+        ``type``
+            This must always be ``simple`` for this method.
+        ``value``
+            This contains the raw value of the secret token.
+        ``encoding``
+            (Optional) If present, how to decode the value from how it's
+            encoded at rest (only ``base64`` currently supported).
+
+        :rtype: :py:class:`bytes`
+
+        """
+        secret_attributes = self.get_raw(path)
+
+        if secret_attributes.get("type") != "simple":
+            raise CorruptSecretError(path, "secret does not have type=simple")
+
+        try:
+            value = secret_attributes["value"]
+        except KeyError:
+            raise CorruptSecretError(path, "secret does not have value")
+
+        encoding = secret_attributes.get("encoding", "identity")
+        return _decode_secret(path, encoding, value)
+
+    def get_versioned(self, path):
+        """Decode and return a versioned secret.
+
+        Versioned secrets are a convention of key/value pairs in the raw secret
+        payload. The following keys are significant:
+
+        ``type``
+            This must always be ``versioned`` for this method.
+        ``current``, ``next``, and ``previous``
+            The raw secret value's versions. ``current`` is the "active"
+            version, which is used for new creation/signing operations.
+            ``previous`` and ``next`` are only used for validation (e.g.
+            checking signatures) to ensure continuity when keys rotate. Both
+            ``previous`` and ``next`` are optional.
+        ``encoding``
+            (Optional) If present, how to decode the values from how they are
+            encoded at rest (only ``base64`` currently supported).
+
+        :rtype: :py:class:`VersionedSecret`
+
+        """
+        secret_attributes = self.get_raw(path)
+
+        if secret_attributes.get("type") != "versioned":
+            raise CorruptSecretError(path, "secret does not have type=versioned")
+
+        previous_value = secret_attributes.get("previous")
+        next_value = secret_attributes.get("next")
+
+        try:
+            current_value = secret_attributes["current"]
+        except KeyError as exc:
+            raise CorruptSecretError(path, "secret does not have %s" % exc)
+
+        encoding = secret_attributes.get("encoding", "identity")
+        return VersionedSecret(
+            previous=previous_value and _decode_secret(path, encoding, previous_value),
+            current=_decode_secret(path, encoding, current_value),
+            next=next_value and _decode_secret(path, encoding, next_value),
+        )
+
+    def make_object_for_context(self, name, server_span):  # pragma: nocover
+        """Return an object that can be added to the context object.
+
+        This allows the secret store to be used with
+        :py:meth:`~baseplate.core.Baseplate.add_to_context`::
+
+           secrets = SecretsStore("/var/local/secrets.json")
+           baseplate.add_to_context("secrets", secrets)
+
+        """
+        return self
+
+
+def secrets_store_from_config(app_config):
+    """Configure and return a secrets store.
+
+    This expects one configuration option:
+
+    ``secrets.path``
+        The path to the secrets file generated by the secrets fetcher daemon.
+
+    :param dict raw_config: The app configuration which should have settings
+        for the secrets store.
+    :rtype: :py:class:`SecretsStore`
+
+    """
+    cfg = config.parse_config(app_config, {
+        "secrets": {
+            "path": config.String,
+        },
+    })
+    # pylint: disable=no-member
+    return SecretsStore(cfg.secrets.path)

--- a/docs/baseplate/crypto.rst
+++ b/docs/baseplate/crypto.rst
@@ -6,8 +6,9 @@ baseplate.crypto
 Message Signing
 ---------------
 
-.. autoclass:: MessageSigner
-   :members:
+.. autofunction:: make_signature
+
+.. autofunction:: validate_signature
 
 .. autoclass:: SignatureInfo
 

--- a/docs/baseplate/index.rst
+++ b/docs/baseplate/index.rst
@@ -3,6 +3,6 @@ baseplate
 
 .. automodule:: baseplate
 
-.. autofunction:: make_metrics_client
-.. autofunction:: make_tracing_client
+.. autofunction:: metrics_client_from_config
+.. autofunction:: tracing_client_from_config
 .. autofunction:: error_reporter_from_config

--- a/docs/baseplate/secrets.rst
+++ b/docs/baseplate/secrets.rst
@@ -1,0 +1,41 @@
+baseplate.secrets
+=================
+
+.. automodule:: baseplate.secrets
+
+Fetcher Daemon
+--------------
+
+The secret fetcher is a sidecar that is run as a single daemon on each server.
+It authenticates to Vault as the server itself and gets appropriate policies
+for access to secrets accordingly. Once authenticated, it fetches a given list
+of secrets from Vault and stores all of the data in a local file. It will
+automatically re-fetch secrets as their leases expire, ensuring that key
+rotation happens on schedule.
+
+Because this is a sidecar, individual application processes don't need to talk
+directly to Vault for simple secret tokens (but can do so if needed for more
+complex operations like using the Transit backend). This reduces the load on
+Vault and adds a safety net if Vault becomes unavailable.
+
+
+Secret Store
+------------
+
+The secret store is the in-application integration with the file output of the
+fetcher daemon.
+
+.. autofunction:: secrets_store_from_config
+
+.. autoclass:: SecretsStore
+   :members:
+
+.. autoclass:: VersionedSecret
+   :members:
+
+Exceptions
+~~~~~~~~~~
+
+.. autoexception:: CorruptSecretError
+
+.. autoexception:: SecretNotFoundError

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,6 +59,7 @@ be used without the framework.
    baseplate.metrics: Counters and timers for statsd <baseplate/metrics>
    baseplate.random: Extensions to the standard library's random module <baseplate/random>
    baseplate.retry: Policies for retrying operations <baseplate/retry>
+   baseplate.secrets: Secure storage and access to secret tokens and credentials <baseplate/secrets>
    baseplate.thrift_pool: A Thrift client connection pool <baseplate/thrift_pool>
    baseplate.service_discovery: Integration with Synapse service discovery <baseplate/service_discovery>
 

--- a/docs/secrets.json
+++ b/docs/secrets.json
@@ -1,0 +1,10 @@
+{
+    "secrets": {
+        "some_signing_key": {
+            "type": "versioned",
+            "current": "aHVudGVyMg==",
+            "encoding": "base64"
+        }
+    },
+    "vault_token": "17213328-36d4-11e7-8459-525400f56d04"
+}

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -46,5 +46,7 @@ subclassing
 sysctls
 unpickle
 unsampled
+versioned
+Versioned
 walkthrough
 Zipkin

--- a/tests/unit/secrets/store_tests.py
+++ b/tests/unit/secrets/store_tests.py
@@ -1,0 +1,210 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import datetime
+import tempfile
+import unittest
+
+from baseplate.secrets import store
+
+from ... import mock
+
+
+class StoreTests(unittest.TestCase):
+    def setUp(self):
+        real_datetime = datetime.datetime
+        datetime_patcher = mock.patch("datetime.datetime", autospec=True)
+        self.addCleanup(datetime_patcher.stop)
+        self.mock_datetime_cls = datetime_patcher.start()
+        self.mock_datetime_cls.side_effect = lambda *a, **kw: real_datetime(*a, **kw)
+        self.mock_datetime_cls.min = real_datetime.min
+        self.mock_datetime_cls.strptime = real_datetime.strptime
+        self.mock_datetime_cls.utcnow.return_value = datetime.datetime(2017, 5, 5, 9, 35)
+
+        self.tempfile = tempfile.NamedTemporaryFile()
+
+    def _fill_secrets_file(self, data):
+        self.tempfile.seek(0)
+        self.tempfile.write(data.encode("utf8"))
+        self.tempfile.flush()
+
+    def test_initial_fetch_loads_secrets(self):
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {"a": 1}
+            },
+            "vault_token": "test"
+        }""")
+
+        secrets = store.SecretsStore(self.tempfile.name)
+        secret = secrets.get_raw("test")
+
+        self.assertEqual(secret, {"a": 1})
+        self.assertEqual(secrets.get_vault_token(), "test")
+
+        with self.assertRaises(store.SecretNotFoundError):
+            secrets.get_raw("does_not_exist")
+
+    @mock.patch("os.fstat")
+    @mock.patch("os.path.getmtime")
+    def test_dont_reload_while_not_changed(self, getmtime, fstat):
+        getmtime.return_value = 1
+        fstat.return_value = mock.Mock(st_mtime=1)
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {"a": 1}
+            },
+            "vault_token": "test1"
+        }""")
+
+        secrets = store.SecretsStore(self.tempfile.name)
+        self.assertEqual(secrets.get_raw("test"), {"a": 1})
+
+        # this will not parse, so we know we didn't reload if we don't crash!
+        self._fill_secrets_file("!")
+        self.assertEqual(secrets.get_raw("test"), {"a": 1})
+
+    # we patch the mtime stuff because it has whole-second granularity and it's
+    # best not to make the tests take longer just to ensure we tick over.
+    @mock.patch("os.fstat")
+    @mock.patch("os.path.getmtime")
+    def test_reload_when_mtime_changes(self, getmtime, fstat):
+        getmtime.return_value = 1
+        fstat.return_value = mock.Mock(st_mtime=1)
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {"a": 1}
+            },
+            "vault_token": "test1"
+        }""")
+
+        secrets = store.SecretsStore(self.tempfile.name)
+        self.assertEqual(secrets.get_raw("test"), {"a": 1})
+
+        getmtime.return_value = 2
+        fstat.return_value = mock.Mock(st_mtime=2)
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {"a": 2}
+            },
+            "vault_token": "test1"
+        }""")
+        self.assertEqual(secrets.get_raw("test"), {"a": 2})
+
+    def test_simple_secrets(self):
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {
+                    "type": "simple",
+                    "value": "easy"
+                },
+                "test_base64": {
+                    "type": "simple",
+                    "value": "aHVudGVyMg==",
+                    "encoding": "base64"
+                },
+                "test_unknown_encoding": {
+                    "type": "simple",
+                    "value": "sdlfkj",
+                    "encoding": "mystery"
+                },
+                "test_not_simple": {
+                    "something": "else"
+                },
+                "test_no_value": {
+                    "type": "simple"
+                },
+                "test_bad_base64": {
+                    "type": "simple",
+                    "value": "aHVudGVyMg",
+                    "encoding": "base64"
+                }
+            },
+            "vault_token": "test1"
+        }""")
+
+        secrets = store.SecretsStore(self.tempfile.name)
+
+        self.assertEqual(secrets.get_simple("test"), b"easy")
+        self.assertEqual(secrets.get_simple("test_base64"), b"hunter2")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_simple("test_unknown_encoding")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_simple("test_not_simple")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_simple("test_no_value")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_simple("test_bad_base64")
+
+    def test_versioned_secrets(self):
+        self._fill_secrets_file("""{
+            "secrets": {
+                "test": {
+                    "type": "versioned",
+                    "current": "easy"
+                },
+                "test_base64": {
+                    "type": "versioned",
+                    "previous": "aHVudGVyMQ==",
+                    "current": "aHVudGVyMg==",
+                    "next": "aHVudGVyMw==",
+                    "encoding": "base64"
+                },
+                "test_unknown_encoding": {
+                    "type": "versioned",
+                    "current": "sdlfkj",
+                    "encoding": "mystery"
+                },
+                "test_not_versioned": {
+                    "something": "else"
+                },
+                "test_no_value": {
+                    "type": "versioned"
+                },
+                "test_bad_base64": {
+                    "type": "simple",
+                    "value": "aHVudGVyMg",
+                    "encoding": "base64"
+                }
+            },
+            "vault_token": "test1"
+        }""")
+
+        secrets = store.SecretsStore(self.tempfile.name)
+
+        simple = secrets.get_versioned("test")
+        self.assertEqual(simple.current, b"easy")
+        self.assertEqual(list(simple.all_versions), [b"easy"])
+
+        encoded = secrets.get_versioned("test_base64")
+        self.assertEqual(encoded.previous, b"hunter1")
+        self.assertEqual(encoded.current, b"hunter2")
+        self.assertEqual(encoded.next, b"hunter3")
+        self.assertEqual(list(encoded.all_versions),
+                         [b"hunter2", b"hunter1", b"hunter3"])
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_versioned("test_unknown_encoding")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_versioned("test_not_versioned")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_versioned("test_no_value")
+
+        with self.assertRaises(store.CorruptSecretError):
+            secrets.get_versioned("test_bad_base64")
+
+
+class StoreFromConfigTests(unittest.TestCase):
+    def test_make_store(self):
+        secrets = store.secrets_store_from_config({
+            "secrets.path": "/tmp/test",
+        })
+        self.assertIsInstance(secrets, store.SecretsStore)


### PR DESCRIPTION
This adds support for secrets stored in Hashicorp Vault. What _is_ here should be heavily documented in the diff itself, so I'll defer to that rather than writing more here in the PR body. This is all rather much, so please do tear it apart and let me know if anything is confusing, misleading, dangerous, insecure, etc.

Open questions:

* monitoring of fetcher daemon: The daemon will run as an appcommon::daemon which means we'll get log shipping and QA checks for free. There's not any facility for alerting on sudden failure down the line though. 

Future work:

* [HVAC](https://github.com/ianunruh/hvac) integration. The integration should take the vault_token from this stuff and allow full in-app access to vault's more interesting features (like the transit backend). All with diagnostics instrumentation, of course!
* [Database credentials](https://www.vaultproject.io/docs/secrets/databases/index.html): The database helpers should get integration with the Vault stuff so that apps can automatically fetch rotating DB credentials. 