### PR TITLE
Suppress noisy urllib3 INFO logging.

### DIFF
--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -25,6 +25,8 @@ from ..core import (
 
 logger = logging.getLogger(__name__)
 
+# Suppress noisy INFO logging of underlying connection management module
+logging.getLogger("urllib3.connectionpool").setLevel(logging.WARNING)
 
 # Span annotation types
 ANNOTATIONS = {


### PR DESCRIPTION
urllib3.connectionpool is the underlying module backing
connection pools that are created for Zipkin connections.
There are spammy INFO-level connection logs that should
be suppressed.

This is for https://reddit.atlassian.net/browse/IO-1855

Do we want to do this more generally anywhere? This seemed reasonable to me since this tracing module might be used standalone. 

:eyeglasses: @spladug 