### PR TITLE
Switch to ReadTheDocs for documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ including:
 -  and various helper libraries like a Thrift client pool
 
 Check out the `quick
-start <http://reddit.github.io/baseplate/quickstart.html>`__ to get
+start <https://baseplate.readthedocs.io/en/stable/quickstart.html>`__ to get
 going quickly, or read the `full
-docs <http://reddit.github.io/baseplate/index.html>`__.
+docs <https://baseplate.readthedocs.io/en/stable/>`__.
 
 .. |Build Status| image:: https://travis-ci.org/reddit/baseplate.svg?branch=master
    :target: https://travis-ci.org/reddit/baseplate

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -138,6 +138,7 @@ your application's :py:class:`~baseplate.core.Baseplate` object.
 - Logging: :py:meth:`~baseplate.core.Baseplate.configure_logging`
 - Metrics (statsd): :py:meth:`~baseplate.core.Baseplate.configure_metrics`
 - Tracing (Zipkin): :py:meth:`~baseplate.core.Baseplate.configure_tracing`
+- Error Reporting (Sentry): :py:meth:`~baseplate.core.Baseplate.configure_error_reporting`
 
 Additionally, Baseplate provides helpers which can be attached to the
 :term:`context object` in requests. These helpers make the passing of trace

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,10 @@
+# requirements for building the sphinx docs
+alabaster
+cassandra-driver
+git+https://github.com/reddit/fbthrift.git@patch-queue/ubuntu/trusty#egg=thrift&subdirectory=thrift/lib/py/
+posix_ipc
+pymemcache
+pyramid
+redis
+sphinxcontrib-spelling
+SQLAlchemy

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     author="Neil Williams",
     author_email="neil@reddit.com",
     license="BSD",
-    url="https://reddit.github.io/baseplate/",
+    url="https://baseplate.readthedocs.io/en/stable/",
     version="0.18.0",
 
     packages=find_packages(exclude=["tests", "tests.*"]),


### PR DESCRIPTION
This allows the build process to be automated without giving
write-access credentials to CI. Additionally, it lets us have multiple
versions of docs live for when multiple releases are around.

Also a quick place I missed while doing the sentry stuff that I noticed
while doing this.