### PR TITLE
Add explicit shadowing method for wrapped context attributes.

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -60,4 +60,4 @@ class ContextObserver(BaseplateObserver):
     def on_child_span_created(self, child_span):
         if isinstance(child_span, LocalSpan):
             context_attr = self.context_factory.make_object_for_context(self.name, child_span)
-            setattr(child_span.context, self.name, context_attr)
+            child_span.context.shadow_context_attr(self.name, context_attr)

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -376,7 +376,7 @@ class LocalSpan(Span):
             if component_name is None:
                 raise ValueError("Cannot create local span without component name.")
             span.component_name = component_name
-            context_copy.trace = span
+            context_copy.shadow_context_attr('trace', span)
         else:
             span = Span(self.trace_id, self.id, span_id, self.sampled, self.flags, name, self.context)
         for observer in self.observers:

--- a/baseplate/integration/wrapped_context.py
+++ b/baseplate/integration/wrapped_context.py
@@ -2,6 +2,14 @@ import logging
 
 
 class WrappedRequestContext(object):
+    """A class for wrapping request contexts to add custom attributes.
+
+    This class is used to wrap framework request contexts in order to
+    shadow certain attributes like Baseplate-included context clients
+    within Baseplate integration code without modifying the underlying
+    context. Users can still access the underlying context through
+    the standard getattr/setattr interface.
+    """
     def __init__(self, context, trace=None):
         self.__dict__['_context'] = context
         self.__dict__['logger'] = logging.getLogger(self.__class__.__name__)
@@ -10,11 +18,17 @@ class WrappedRequestContext(object):
         return getattr(self._context, attr)
 
     def __setattr__(self, attr, value):
-        if attr in self._context.__dict__:
-            self._context.__setattr__(attr, value)
-        else:
-            self.logger.debug("Assigning new attr=%s to wrapped request context.")
-            super(WrappedRequestContext, self).__setattr__(attr, value)
+        self._context.__setattr__(attr, value)
+
+    def shadow_context_attr(self, attr, value):
+        """Explicit method for shadowing Baseplate-specific context attributes.
+
+        This should be used for adding/modifying context attributes
+        like context clients and traces when you don't want to change the
+        underlying framework context. This is useful for manipulating
+        local-span-aware attributes.
+        """
+        super(WrappedRequestContext, self).__setattr__(attr, value)
 
     def clone(self):
         new_wrapped_context = WrappedRequestContext(self._context)

--- a/tests/unit/context/tests.py
+++ b/tests/unit/context/tests.py
@@ -10,6 +10,7 @@ from baseplate.core import (
     LocalSpan,
     Span,
 )
+from baseplate.integration import WrappedRequestContext
 
 from ... import mock
 
@@ -29,6 +30,7 @@ class ContextObserverTests(unittest.TestCase):
     def test_add_to_context_local(self):
         mock_factory = mock.Mock(spec=ContextFactory)
         mock_context = mock.Mock()
+        mock_context = WrappedRequestContext(mock_context)
         mock_local_span = mock.Mock(spec=LocalSpan)
         mock_local_span.component_name = 'test_component'
         mock_local_span.context = mock_context

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -172,7 +172,7 @@ class ServerSpanTests(unittest.TestCase):
         server_span = ServerSpan("trace", "parent", "id", None, 0, "name", mock_context)
         server_span.register(mock_observer)
         local_span = server_span.make_child("test_op", local=True,
-                                                           component_name="test_component")
+                                            component_name="test_component")
         self.assertNotEqual(local_span.context, mock_context)
 
 


### PR DESCRIPTION
Wrapped contexts for local spans need to support shadowing
currently existing context attributes for substitution in certain
situations like within a local span as well as adding/overriding
attributes of the underlying context for developer ease. The single
setattr override in WrappedRequestContext could not do shadowing
properly on its own since it would always modify the underlying context directly 
if the attribute existed. Since shadowing should only happen within
Baseplate-specific integration code (application developers should
not need this capability directly as they shouldn't be modifying
Baseplate-added context attributes themselves), WrappedRequestContext
utilizes the standard setattr interface to access the underlying
context. This adds an explicit method to shadow attributes by assigning
directly to the WrappedRequestContext object.


This still needs a few more tests I think but wanted to get feedback on the approach to solving the issue I hope is properly described above. Happy to answer any other questions about my train of thought. 

:eyeglasses: @spladug  @dellis23 