### PR TITLE
Do a polish/cleanup pass on the docs

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -1,9 +1,8 @@
 """Helpers that integrate common client libraries with baseplate's diagnostics.
 
 This package contains modules which integrate various client libraries with
-Baseplate's diagnostics and tracing facilities. When using these helpers,
-trace information and monitoring are automatically collected and sent on for
-you.
+Baseplate's instrumentation. When using them, trace information is passed on
+and metrics are collected automatically.
 
 To use these helpers, use the
 :py:meth:`~baseplate.core.Baseplate.add_to_context` method on your
@@ -17,9 +16,6 @@ and then a context-aware version of the client will show up on the
 
     def my_handler(self, context):
         context.my_client.make_some_remote_call()
-
-If a library you want isn't supported here, it can be added to your own
-application by subclassing :py:class:`~baseplate.context.ContextFactory`.
 
 """
 from __future__ import absolute_import

--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -1,8 +1,8 @@
 """Helpers that integrate common client libraries with baseplate's diagnostics.
 
 This package contains modules which integrate various client libraries with
-Baseplate's instrumentation. When using them, trace information is passed on
-and metrics are collected automatically.
+Baseplate's instrumentation. When using these client library integrations,
+trace information is passed on and metrics are collected automatically.
 
 To use these helpers, use the
 :py:meth:`~baseplate.core.Baseplate.add_to_context` method on your

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -22,7 +22,8 @@ class ThriftContextFactory(ContextFactory):
     the connection pool and execute the RPC, automatically recording diagnostic
     information.
 
-    :param baseplate.thrift_pool.ConnectionPool pool: The connection pool.
+    :param baseplate.thrift_pool.ThriftConnectionPool pool: The connection
+        pool.
     :param client_cls: The class object of a Thrift-generated client class,
         e.g. ``YourService.Client``.
 

--- a/baseplate/integration/__init__.py
+++ b/baseplate/integration/__init__.py
@@ -1,4 +1,4 @@
-"""Helpers for integration with various frameworks.
+"""Helpers for integration with various application frameworks.
 
 This package contains modules which integrate Baseplate with common
 application frameworks.

--- a/docs/baseplate/context/cassandra.rst
+++ b/docs/baseplate/context/cassandra.rst
@@ -1,0 +1,16 @@
+baseplate.context.cassandra
+===========================
+
+.. automodule:: baseplate.context.cassandra
+
+Configuration Parsing
+---------------------
+
+.. autofunction:: baseplate.context.cassandra.cluster_from_config
+
+Classes
+-------
+
+.. autoclass:: baseplate.context.cassandra.CassandraContextFactory
+
+.. autoclass:: baseplate.context.cassandra.CQLMapperContextFactory

--- a/docs/baseplate/context/index.rst
+++ b/docs/baseplate/context/index.rst
@@ -3,72 +3,23 @@ baseplate.context
 
 .. automodule:: baseplate.context
 
+Instrumented Client Libraries
+-----------------------------
 
-Services
---------
+.. toctree::
+   :titlesonly:
 
-.. autoclass:: baseplate.context.thrift.ThriftContextFactory
-
-
-Cassandra
----------
-
-.. autofunction:: baseplate.context.cassandra.cluster_from_config
-
-.. autoclass:: baseplate.context.cassandra.CassandraContextFactory
-
-.. autoclass:: baseplate.context.cassandra.CQLMapperContextFactory
-
-
-Memcache
---------
-
-.. autofunction:: baseplate.context.memcache.pool_from_config
-
-.. autoclass:: baseplate.context.memcache.MemcacheContextFactory
-   :members:
-
-.. autoclass:: baseplate.context.memcache.MonitoredMemcacheConnection
-   :members:
-
-.. autofunction:: baseplate.context.memcache.lib.decompress_and_load
-
-.. autofunction:: baseplate.context.memcache.lib.make_dump_and_compress_fn
-
-.. autofunction:: baseplate.context.memcache.lib.decompress_and_unpickle
-
-.. autofunction:: baseplate.context.memcache.lib.make_pickle_and_compress_fn
-
-
-Redis
------
-
-.. autofunction:: baseplate.context.redis.pool_from_config
-
-.. autoclass:: baseplate.context.redis.RedisContextFactory
-   :members:
-
-.. autoclass:: baseplate.context.redis.MonitoredRedisConnection
-   :members:
-
-
-SQLAlchemy
-----------
-
-.. autoclass:: baseplate.context.sqlalchemy.SQLAlchemyEngineContextFactory
-
-.. autoclass:: baseplate.context.sqlalchemy.SQLAlchemySessionContextFactory
-
+   baseplate.context.cassandra: Cassandra CQL Client <cassandra>
+   baseplate.context.memcache: Memcached Client <memcache>
+   baseplate.context.redis: Redis Client <redis>
+   baseplate.context.sqlalchemy: SQL Client for relational databases (e.g. PostgreSQL) <sqlalchemy>
+   baseplate.context.thrift: Thrift client for RPC to other backend services <thrift>
 
 DIY: The Factory
 ----------------
 
-.. note::
-
-   Stuff beyond this point is only useful if you are implementing your own
-   context helpers. You can stop reading here if the stuff above already has
-   you covered!
-
+If a library you want isn't supported here, it can be added to your own
+application by subclassing :py:class:`~baseplate.context.ContextFactory`.
 
 .. autoclass:: baseplate.context.ContextFactory
    :members:

--- a/docs/baseplate/context/memcache.rst
+++ b/docs/baseplate/context/memcache.rst
@@ -1,0 +1,29 @@
+baseplate.context.memcache
+==========================
+
+.. automodule:: baseplate.context.memcache
+
+Configuration Parsing
+---------------------
+
+.. autofunction:: baseplate.context.memcache.pool_from_config
+
+Classes
+-------
+
+.. autoclass:: baseplate.context.memcache.MemcacheContextFactory
+   :members:
+
+.. autoclass:: baseplate.context.memcache.MonitoredMemcacheConnection
+   :members:
+
+Serialization/deserialization helpers
+-------------------------------------
+
+.. autofunction:: baseplate.context.memcache.lib.decompress_and_load
+
+.. autofunction:: baseplate.context.memcache.lib.make_dump_and_compress_fn
+
+.. autofunction:: baseplate.context.memcache.lib.decompress_and_unpickle
+
+.. autofunction:: baseplate.context.memcache.lib.make_pickle_and_compress_fn

--- a/docs/baseplate/context/redis.rst
+++ b/docs/baseplate/context/redis.rst
@@ -1,0 +1,18 @@
+baseplate.context.redis
+=======================
+
+.. automodule:: baseplate.context.redis
+
+Configuration Parsing
+---------------------
+
+.. autofunction:: baseplate.context.redis.pool_from_config
+
+Classes
+-------
+
+.. autoclass:: baseplate.context.redis.RedisContextFactory
+   :members:
+
+.. autoclass:: baseplate.context.redis.MonitoredRedisConnection
+   :members:

--- a/docs/baseplate/context/sqlalchemy.rst
+++ b/docs/baseplate/context/sqlalchemy.rst
@@ -1,0 +1,17 @@
+baseplate.context.sqlalchemy
+============================
+
+.. automodule:: baseplate.context.sqlalchemy
+
+Configuration Parsing
+---------------------
+
+.. autofunction:: sqlalchemy.engine_from_config
+
+
+Classes
+-------
+
+.. autoclass:: baseplate.context.sqlalchemy.SQLAlchemyEngineContextFactory
+
+.. autoclass:: baseplate.context.sqlalchemy.SQLAlchemySessionContextFactory

--- a/docs/baseplate/context/thrift.rst
+++ b/docs/baseplate/context/thrift.rst
@@ -1,0 +1,6 @@
+baseplate.context.thrift
+========================
+
+.. automodule:: baseplate.context.thrift
+
+.. autoclass:: baseplate.context.thrift.ThriftContextFactory

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -2,7 +2,7 @@ baseplate.core
 ==============
 
 The heart of the Baseplate framework is its diagnostics system. Here's an
-incomplete example of an application built on the framework::
+incomplete example of an application built with the framework::
 
    def do_something(request):
        request.some_redis_client.ping()
@@ -18,12 +18,14 @@ incomplete example of an application built on the framework::
        ... snip ...
 
 When a request is made which routes to the ``do_something`` handler, a
-:py:class:`~baseplate.core.ServerSpan` is automatically created. If the incoming
-request has trace headers, we construct the server span to be identical to the
-child span in the upstream service. When we call
-``request.some_redis_client.ping()`` in the handler, Baseplate will create a
-child :py:class:`~baseplate.core.Span` object to represent the time taken
-talking to redis.
+:py:class:`~baseplate.core.ServerSpan` is automatically created to represent
+the time spent processing the request in our application. If the incoming
+request has trace headers, the constructed server span will have the same IDs
+as the upstream service's child span.
+
+When we call ``request.some_redis_client.ping()`` in the handler, Baseplate
+will create a child :py:class:`~baseplate.core.Span` object to represent the
+time taken talking to redis.
 
 The creation of the server and child spans will trigger updates on all the
 :py:class:`~baseplate.core.ServerSpanObserver` and
@@ -37,8 +39,8 @@ our ``ping`` to statsd/Graphite without any extra code in our application.
 
    The documentation below explains how all this works under the hood. If you
    just want to write an application, you can skip on to :doc:`how to integrate
-   Baseplate with your application framework <integration/index>` or :doc:`how to
-   add client libraries to the context object <context/index>`.
+   Baseplate with your application framework <integration/index>` or :doc:`how
+   to use client libraries with diagnostic instrumentation <context/index>`.
 
 .. automodule:: baseplate.core
 
@@ -99,19 +101,19 @@ called with the relevant details. This method can register
 :py:class:`~baseplate.core.ServerSpanObserver` instances with the new server
 span to receive events as they happen.
 
-Spans can be notified of four common events:
-:py:meth:`~baseplate.core.SpanObserver.on_start`,
-:py:meth:`~baseplate.core.SpanObserver.on_set_tag`, and
-:py:meth:`~baseplate.core.SpanObserver.on_log`, and
-:py:meth:`~baseplate.core.SpanObserver.on_finish`. These represent the span
-starting, having tags set, logs entered, and ending, respectively.
+Spans can be notified of five common events:
 
-Additionally, :py:class:`~baseplate.core.ServerSpanObserver` has one extra
-event, :py:meth:`~baseplate.core.ServerSpanObserver.on_child_span_created`.
-This method is called when a new child span is created in the application for
-e.g. a call to a remote service or an expensive computation. This method can
-register :py:class:`~baseplate.core.SpanObserver` instances with the new child
-span to receive events as they happen.
+* :py:meth:`~baseplate.core.SpanObserver.on_start`, the span started.
+* :py:meth:`~baseplate.core.SpanObserver.on_set_tag`, a tag was set on the span.
+* :py:meth:`~baseplate.core.SpanObserver.on_log`, a log was entered on the span.
+* :py:meth:`~baseplate.core.SpanObserver.on_finish`, the span finished.
+* :py:meth:`~baseplate.core.SpanObserver.on_child_span_created`, a new child span was created.
+
+New child spans are created in the application automatically by various client
+library instrumentations e.g. for a call to a remote service or database, and
+can also be created explicitly for local actions like expensive computations.
+The handler can register new :py:class:`~baseplate.core.SpanObserver` instances
+with the new child span to receive events as they happen.
 
 It's up to the observers to attach meaning to these events. For example, the
 metrics observer would start a timer
@@ -128,8 +130,11 @@ statsd :py:meth:`~!baseplate.core.SpanObserver.on_finish`.
 .. autoclass:: SpanObserver
    :members:
 
-Convenience
------------
+
+.. _convenience_methods:
+
+Convenience Methods
+-------------------
 
 Baseplate comes with some core monitoring observers built in and just requires
 you to configure them. You can enable them by calling the relevant methods on

--- a/docs/baseplate/diagnostics/index.rst
+++ b/docs/baseplate/diagnostics/index.rst
@@ -10,10 +10,14 @@ Observers watch Baseplate for events that happen during requests, such as
 requests starting and ending and service calls being made. Observers can also
 add attributes to the :term:`context object` for your application to use during
 the request. Under the hood, the context factories
-(:py:mod:`baseplate.context`) are implemented as observers.
+(:py:mod:`baseplate.context`) are implemented as observers. All of the
+following observers can be configured with :ref:`convenience_methods` on your
+application's :py:class:`~baseplate.core.Baseplate` object.
 
 .. autoclass:: baseplate.diagnostics.logging.LoggingBaseplateObserver
 
 .. autoclass:: baseplate.diagnostics.metrics.MetricsBaseplateObserver
+
+.. autoclass:: baseplate.diagnostics.sentry.SentryBaseplateObserver
 
 .. autoclass:: baseplate.diagnostics.tracing.TraceBaseplateObserver

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,40 +3,20 @@ Baseplate
 
 Baseplate is a framework to build services on and a library of common and
 well-tested code to share. Its goal is to provide all the common things a
-service needs with as few surprises as possible.
+service needs with as few surprises as possible. It can be divided up into
+three distinct categories of components, listed below. If you're just getting
+started or just impatient, check out the :doc:`quickstart`.
 
-Introduction
-------------
+The Instrumentation Framework
+-----------------------------
 
-.. toctree::
-   :titlesonly:
-
-   quickstart
-
-The CLI Toolkit
----------------
-
-These are helper tools for running and supporting applications in production
-and development.
+Baseplate provides an instrumentation framework that integrates with popular
+application frameworks to provide automatic diagnostics to services.
 
 .. toctree::
    :titlesonly:
 
-   baseplate-healthcheck: Is your service alive? <cli/healthcheck>
-   baseplate-serve: The application server <cli/serve>
-   baseplate-script: Run backend scripts <cli/script>
-
-The Framework
--------------
-
-Baseplate provides an opinionated and integrated framework for making server
-applications.  This framework provides monitoring, logging, and tracing out of
-the box.
-
-.. toctree::
-   :titlesonly:
-
-   baseplate.core: The guts of the diagnostics framework <baseplate/core>
+   baseplate.core: The skeleton of the instrumentation framework <baseplate/core>
    baseplate.context: Integration with client libraries <baseplate/context/index>
    baseplate.integration: Integration with application frameworks <baseplate/integration/index>
    baseplate.diagnostics: Diagnostics observers <baseplate/diagnostics/index>
@@ -44,9 +24,9 @@ the box.
 The Library
 -----------
 
-These modules are relatively disconnected and provide various pieces of
-functionality that are commonly needed in production applications. They can
-be used without the framework.
+Baseplate also provides a collection of "extra batteries", independent modules
+that provide commonly needed functionality to applications. They can be used
+separately from the rest of Baseplate.
 
 .. toctree::
    :titlesonly:
@@ -63,15 +43,28 @@ be used without the framework.
    baseplate.thrift_pool: A Thrift client connection pool <baseplate/thrift_pool>
    baseplate.service_discovery: Integration with Synapse service discovery <baseplate/service_discovery>
 
-Other
------
+The CLI Toolkit
+---------------
+
+Baseplate provides command line tools which are useful for running applications
+in production and development.
+
+.. toctree::
+   :titlesonly:
+
+   baseplate-healthcheck: Is your service alive? <cli/healthcheck>
+   baseplate-serve: The application server <cli/serve>
+   baseplate-script: Run backend scripts <cli/script>
+
+Appendix
+--------
 
 * :ref:`genindex`
 * :ref:`modindex`
 * :doc:`glossary`
 
 .. toctree::
-   :titlesonly:
    :hidden:
 
+   quickstart
    glossary

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,8 +24,8 @@ application frameworks to provide automatic diagnostics to services.
 The Library
 -----------
 
-Baseplate also provides a collection of "extra batteries", independent modules
-that provide commonly needed functionality to applications. They can be used
+Baseplate also provides a collection of "extra batteries". These independent
+modules provide commonly needed functionality to applications. They can be used
 separately from the rest of Baseplate.
 
 .. toctree::

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -1,20 +1,8 @@
 Quick Start
 ===========
 
-Installation
-------------
-
-To install Baseplate, use the debian packages::
-
-   sudo add-apt-repository ppa:reddit/ppa
-   sudo apt-get update
-   sudo apt-get install python-gevent python-baseplate
-
-Cookiecutter
-------------
-
 Baseplate has a project generation tool to help you get started.
-Install it::
+Install it on your development machine::
 
    pip install git+https://github.com/reddit/baseplate-cookiecutter
 
@@ -22,18 +10,6 @@ Then run the tool and follow the prompts::
 
    baseplate-cookiecutter
 
-The templates have liberal "TODO"s for you to fill in your application. Good
-luck!
-
-Serving
--------
-
-Once your service is ready (or right now if you are impatient)  you can start
-serving requests::
-
-   baseplate-serve2 example.ini
-
-For more info on this mysterious ``baseplate-serve2``, check out the `chapter
-about the baseplate server`_.
-
-.. _chapter about the baseplate server: cli/serve.html
+The templates have liberal "TODO"s for you to fill in your application. Once
+you're ready to start running some code, fire it up with the included Vagrant
+or Docker files as described in your project's generated README file.

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -3,11 +3,13 @@ app
 backend
 backends
 backoff
+cassandra
 config
 Config
 configurables
 Cookiecutter
 crypto
+deserialization
 Deserialization
 deserialized
 Einhorn
@@ -41,11 +43,13 @@ revalidate
 rlimit
 serializable
 serializer
+sqlalchemy
 statsd
 subclassing
 sysctls
 unpickle
 unsampled
+url
 versioned
 Versioned
 walkthrough


### PR DESCRIPTION
This tries to streamline, give examples, clarify language, and split out
pages that were getting overly complex.

Here it is rendered: http://baseplate.readthedocs.io/en/docs-polish/