### PR TITLE
Add URL validation utilities

### DIFF
--- a/baseplate/web.py
+++ b/baseplate/web.py
@@ -73,6 +73,8 @@ def is_same_domain(host, patterns):
     for pattern in patterns:
         pattern = pattern.lower()
         matches = (
+            # Use `[:1]` rather than `[0]` so we don't throw an `IndexError`
+            # when given a pattern of `""`
             pattern[:1] == '.' and (host.endswith(pattern) or host == pattern[1:]) or
             pattern == host
         )

--- a/baseplate/web.py
+++ b/baseplate/web.py
@@ -1,0 +1,87 @@
+"""Utilities useful for frontend web services"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import re
+
+from ._compat import urlparse, string_types
+
+# Characters that might cause parsing differences in different implementations
+# Spaces only seem to cause parsing differences when occurring directly before
+# the scheme
+URL_PROBLEMATIC_RE = re.compile(
+    r'(\A\x20|[\x00-\x19\u1680\u180E\u2000-\u2029\u205f\u3000\\])',
+    re.UNICODE
+)
+WEB_SAFE_SCHEMES = {"http", "https"}
+
+
+def is_web_safe_url(url):
+    """Determine if this URL could cause issues with different parsers"""
+
+    # There's no valid reason for this, and just serves to confuse UAs
+    # and urllib2.
+    if url.startswith("///"):
+        return False
+
+    # Reject any URLs that contain characters known to cause parsing
+    # differences between parser implementations
+    if re.search(URL_PROBLEMATIC_RE, url):
+            return False
+
+    parsed = urlparse(url)
+
+    # Double-checking the above
+    if not parsed.hostname and parsed.path.startswith("//"):
+        return False
+
+    # A host-relative link with a scheme like `https:/baz` or `https:?quux`
+    if parsed.scheme and not parsed.hostname:
+        return False
+
+    # Credentials in the netloc?
+    if "@" in parsed.netloc:
+        return False
+
+    # `javascript://www.example.com/%0D%Aalert(1)` is not safe, obviously
+    if parsed.scheme and parsed.scheme.lower() not in WEB_SAFE_SCHEMES:
+        return False
+
+    return True
+
+
+def is_same_domain(host, patterns):
+    """
+    Return ``True`` if the host is either an exact match or a match
+    to the wildcard pattern.
+    Any pattern beginning with a period matches a domain and all of its
+    subdomains. (e.g. ``.example.com`` matches ``example.com`` and
+    ``foo.example.com``). Anything else is an exact string match.
+    An empty pattern is considered equivalent to "no domain".
+    """
+    if not patterns:
+        return False
+    # Normalize `None` to `""`
+    if not host:
+        host = ""
+
+    if isinstance(patterns, string_types):
+        patterns = (patterns.lower(),)
+
+    for pattern in patterns:
+        pattern = pattern.lower()
+        matches = (
+            pattern[:1] == '.' and (host.endswith(pattern) or host == pattern[1:]) or
+            pattern == host
+        )
+        if matches:
+            return True
+    return False
+
+
+def is_safe_redirect_url(url, allowed_bases):
+    if not is_web_safe_url(url):
+        return False
+    return is_same_domain(urlparse(url).hostname, patterns=allowed_bases)

--- a/tests/unit/web_tests.py
+++ b/tests/unit/web_tests.py
@@ -20,9 +20,13 @@ class IsSameDomainTests(unittest.TestCase):
         self.assertFalse(web.is_same_domain("baz.com", patterns))
 
     def test_subdomain_matching(self):
-        self.assertTrue(web.is_same_domain("foo.com", ".foo.com"))
-        self.assertTrue(web.is_same_domain("bar.foo.com", ".foo.com"))
-        self.assertFalse(web.is_same_domain("bar.foo.com", "foo.com"))
+        self.assertTrue(web.is_same_domain("foo.com", {".foo.com"}))
+        self.assertTrue(web.is_same_domain("bar.foo.com", {".foo.com"}))
+        self.assertFalse(web.is_same_domain("bar.foo.com", {"foo.com"}))
+        self.assertTrue(web.is_same_domain("baz.bar.foo.com", {".foo.com"}))
+        self.assertFalse(web.is_same_domain("baz.bar.foo.com", {"bar.foo.com"}))
+        self.assertTrue(web.is_same_domain("baz.bar.foo.com", {".bar.foo.com"}))
+        self.assertFalse(web.is_same_domain("foo.com", {".bar.foo.com"}))
 
 
 class IsWebSafeURLTests(unittest.TestCase):

--- a/tests/unit/web_tests.py
+++ b/tests/unit/web_tests.py
@@ -1,0 +1,128 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from baseplate import web
+
+
+class IsSameDomainTests(unittest.TestCase):
+    def test_string_pattern(self):
+        self.assertTrue(web.is_same_domain("foo.com", "foo.com"))
+        self.assertFalse(web.is_same_domain("baz.com.com", "baz.com"))
+
+    def test_iterable_patterns(self):
+        patterns = {"foo.com", "bar.com"}
+        self.assertTrue(web.is_same_domain("foo.com", patterns))
+        self.assertTrue(web.is_same_domain("bar.com", patterns))
+        self.assertFalse(web.is_same_domain("baz.com", patterns))
+
+    def test_subdomain_matching(self):
+        self.assertTrue(web.is_same_domain("foo.com", ".foo.com"))
+        self.assertTrue(web.is_same_domain("bar.foo.com", ".foo.com"))
+        self.assertFalse(web.is_same_domain("bar.foo.com", "foo.com"))
+
+
+class IsWebSafeURLTests(unittest.TestCase):
+    def assertIsWebSafeUrl(self, url):
+        self.assertTrue(web.is_web_safe_url(url))
+
+    def assertIsNotWebSafeUrl(self, url):
+        self.assertFalse(web.is_web_safe_url(url))
+
+    def test_normal_urls(self):
+        self.assertIsWebSafeUrl("https://example.com/")
+        self.assertIsWebSafeUrl("https://en.example.com/")
+        self.assertIsWebSafeUrl("https://foobar.baz.example.com/quux/?a")
+        self.assertIsWebSafeUrl("#anchorage")
+        self.assertIsWebSafeUrl("?path_relative_queries")
+        self.assertIsWebSafeUrl("/")
+        self.assertIsWebSafeUrl("/cats")
+        self.assertIsWebSafeUrl("/cats/")
+        self.assertIsWebSafeUrl("/cats/#maru")
+        self.assertIsWebSafeUrl("//foobaz.example.com/aa/baz#quux")
+        # XXX: This is technically a legal relative URL, are there any UAs
+        # stupid enough to treat this as absolute?
+        self.assertIsWebSafeUrl("path_relative_subpath.com")
+
+    def test_weird_protocols(self):
+        self.assertIsNotWebSafeUrl(
+            "javascript://example.com/%0d%0aalert(1)"
+        )
+        self.assertIsNotWebSafeUrl("hackery:whatever")
+
+    def test_http_auth(self):
+        # There's no legitimate reason to include HTTP auth details in the URL,
+        # they only serve to confuse everyone involved.
+        # For example, this used to be the behaviour of `UrlParser`, oops!
+        # > UrlParser("http://everyoneforgets:aboutthese@/baz.com/").unparse()
+        # 'http:///baz.com/'
+        self.assertIsNotWebSafeUrl("http://foo:bar@/example.com/")
+
+    def test_browser_quirks(self):
+        # Some browsers try to be helpful and ignore characters in URLs that
+        # they think might have been accidental (I guess due to things like:
+        # `<a href=" http://badathtml.com/ ">`. We need to ignore those when
+        # determining if a URL is local.
+        self.assertIsNotWebSafeUrl("/\x00/example.com")
+        self.assertIsNotWebSafeUrl("\x09//example.com")
+        self.assertIsNotWebSafeUrl(" http://example.com/")
+
+        # This is makes sure we're not vulnerable to a bug in
+        # urlparse / urlunparse.
+        # urlunparse(urlparse("////foo.com")) == "//foo.com"! screwy!
+        self.assertIsNotWebSafeUrl("////example.com/")
+        self.assertIsNotWebSafeUrl("//////example.com/")
+        # Similar, but with a scheme
+        self.assertIsNotWebSafeUrl("http:///example.com/")
+        # Webkit and co like to treat backslashes as equivalent to slashes in
+        # different places, maybe to make OCD Windows users happy.
+        self.assertIsNotWebSafeUrl(r"/\example.com/")
+        # On chrome this goes to example.com, not a subdomain of reddit.com!
+        self.assertIsNotWebSafeUrl(
+            r"http://\\example.com\a.example.com/foo"
+        )
+
+        # Combo attacks!
+        self.assertIsNotWebSafeUrl(r"///\example.com/")
+        self.assertIsNotWebSafeUrl(r"\\example.com")
+        self.assertIsNotWebSafeUrl("/\x00//\\example.com/")
+
+
+class IsSafeRedirectUriTests(unittest.TestCase):
+    ALLOWED_BASES = {"foo.com", ".bar.com"}
+
+    def _getAllowedBases(self, additional_bases):
+        additional_bases = additional_bases or frozenset()
+        return self.ALLOWED_BASES.union(additional_bases)
+
+    def assertIsSafeRedirectUrl(self, url, additional_bases=None):
+        bases = self._getAllowedBases(additional_bases)
+        self.assertTrue(web.is_safe_redirect_url(url, bases))
+
+    def assertIsNotSafeRedirectUrl(self, url, additional_bases=None):
+        bases = self._getAllowedBases(additional_bases)
+        self.assertFalse(web.is_safe_redirect_url(url, bases))
+
+    def test_valid_redirect_urls_allowed(self):
+        self.assertIsSafeRedirectUrl("http://foo.com")
+        self.assertIsSafeRedirectUrl("http://bar.com")
+        self.assertIsSafeRedirectUrl("http://baz.bar.com")
+
+    def test_invalid_redirect_urls_not_allowed(self):
+        self.assertIsNotSafeRedirectUrl("http://bar.foo.com")
+        self.assertIsNotSafeRedirectUrl("http://foo.bar.com.baz")
+        self.assertIsNotSafeRedirectUrl("javascript://bar.com")
+        self.assertIsNotSafeRedirectUrl("http://baz.com")
+
+    def test_host_relative_redirect_urls(self):
+        self.assertIsNotSafeRedirectUrl("/foo")
+        # Having `""` in the allowed_bases list means host-relative URLs
+        # are allowed
+        self.assertIsSafeRedirectUrl("/foo", additional_bases={""})
+
+    def unsafe_urls_disallowed(self):
+        self.assertIsNotSafeRedirectUrl("http://foo:bar@foo.com/")
+        self.assertIsNotSafeRedirectUrl("http://foo.com/\\")


### PR DESCRIPTION
Add utilities useful for determining if a URL is safe to use in an anchor or redirect.

`is_web_safe_url()` is mostly copied from r2, minus the wonky `UrlParser` api.