### PR TITLE
Test cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,13 @@
 [run]
 branch = 1
 omit = */baseplate/thrift/*.py
+
+[report]
+exclude_lines =
+    # re-enable the built-in pragma
+    pragma: nocover
+    # trivially empty implementations shouldn't matter
+    raise NotImplementedError
+    pass
+    # module-import stuff should be minimal
+    if __name__ == .__main__.:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,3 @@
 [run]
 branch = 1
-omit = baseplate/thrift/*.py
+omit = */baseplate/thrift/*.py

--- a/baseplate/config.py
+++ b/baseplate/config.py
@@ -89,12 +89,10 @@ import socket
 class ConfigurationError(Exception):
     """Raised when the configuration violates the spec."""
     def __init__(self, key, error):
-        super(ConfigurationError, self).__init__()
+        super(ConfigurationError, self).__init__(
+            "{}: {}".format(key, error))
         self.key = key
         self.error = error
-
-    def __str__(self):  # pragma: nocover
-        return "{}: {}".format(self.key, self.error)
 
 
 def String(text):

--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -39,7 +39,7 @@ class ContextFactory(object):
 
     """
 
-    def make_object_for_context(self, name, server_span):  # pragma: nocover
+    def make_object_for_context(self, name, server_span):
         """Return an object that can be added to the context object."""
         raise NotImplementedError
 

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -127,13 +127,13 @@ class MonitoredRedisConnection(redis.StrictRedis):
         )
 
     # these commands are not yet implemented, but probably not unimplementable
-    def transaction(self, *args, **kwargs):  # pragma: nocover
+    def transaction(self, *args, **kwargs):
         raise NotImplementedError
 
-    def lock(self, *args, **kwargs):  # pragma: nocover
+    def lock(self, *args, **kwargs):
         raise NotImplementedError
 
-    def pubsub(self, *args, **kwargs):  # pragma: nocover
+    def pubsub(self, *args, **kwargs):
         raise NotImplementedError
 
 

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -13,7 +13,7 @@ from ._utils import warn_deprecated
 class BaseplateObserver(object):
     """Interface for an observer that watches Baseplate."""
 
-    def on_server_span_created(self, context, server_span):  # pragma: nocover
+    def on_server_span_created(self, context, server_span):
         """Called when a server span is created.
 
         :py:class:`Baseplate` calls this when a new request begins.
@@ -26,7 +26,7 @@ class BaseplateObserver(object):
         raise NotImplementedError
 
 
-class SpanObserver(object):  # pragma: nocover
+class SpanObserver(object):
     """Interface for an observer that watches a span."""
 
     def on_start(self):
@@ -50,7 +50,7 @@ class SpanObserver(object):  # pragma: nocover
         """
         pass
 
-    def on_child_span_created(self, span):  # pragma: nocover
+    def on_child_span_created(self, span):
         """Called when a child span is created.
 
         :py:class:`SpanObserver` objects call this when a new child span is
@@ -142,12 +142,12 @@ class Baseplate(object):
         """
         self.observers.append(observer)
 
-    def configure_logging(self):  # pragma: nocover
+    def configure_logging(self):
         """Add request context to the logging system."""
         from .diagnostics.logging import LoggingBaseplateObserver
         self.register(LoggingBaseplateObserver())
 
-    def configure_metrics(self, metrics_client):  # pragma: nocover
+    def configure_metrics(self, metrics_client):
         """Send timing metrics to the given client.
 
         This also adds a :py:class:`baseplate.metrics.Batch` object to the
@@ -190,7 +190,7 @@ class Baseplate(object):
 
         self.register(TraceBaseplateObserver(tracing_client))
 
-    def configure_error_reporting(self, client):  # pragma: nocover
+    def configure_error_reporting(self, client):
         """Send reports for unexpected exceptions to the given client.
 
         This also adds a :py:class:`raven.Client` object to the ``sentry``
@@ -203,7 +203,7 @@ class Baseplate(object):
         from .diagnostics.sentry import SentryBaseplateObserver
         self.register(SentryBaseplateObserver(client))
 
-    def add_to_context(self, name, context_factory):  # pragma: nocover
+    def add_to_context(self, name, context_factory):
         """Add an attribute to each request's context object.
 
         On each request, the factory will be asked to create an appropriate

--- a/baseplate/diagnostics/logging.py
+++ b/baseplate/diagnostics/logging.py
@@ -16,5 +16,5 @@ class LoggingBaseplateObserver(BaseplateObserver):
     the thread name to the current request's trace ID.
 
     """
-    def on_server_span_created(self, context, server_span):  # pragma: nocover
+    def on_server_span_created(self, context, server_span):
         threading.current_thread().name = str(server_span.trace_id)

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -48,7 +48,7 @@ class MetricsServerSpanObserver(SpanObserver):
         self.timer.stop()
         self.batch.flush()
 
-    def on_child_span_created(self, span):  # pragma: nocover
+    def on_child_span_created(self, span):
         if isinstance(span, LocalSpan):
             observer = MetricsLocalSpanObserver(self.batch, span)
         else:

--- a/baseplate/secrets/store.py
+++ b/baseplate/secrets/store.py
@@ -24,34 +24,28 @@ class SecretNotFoundError(Exception):
     """Raised when the requested secret is not in the local vault."""
 
     def __init__(self, name):
-        super(SecretNotFoundError, self).__init__()
+        super(SecretNotFoundError, self).__init__(
+            "secret not found: {!r}".format(name))
         self.name = name
-
-    def __str__(self):  # pragma: nocover
-        return "secret not found: {!r}".format(self.name)
 
 
 class CorruptSecretError(Exception):
     """Raised when the requested secret does not match the expected format."""
 
     def __init__(self, path, message):
-        super(CorruptSecretError, self).__init__()
+        super(CorruptSecretError, self).__init__(
+            "{}: {}".format(path, message))
         self.path = path
         self.message = message
-
-    def __str__(self):  # pragma: nocover
-        return "{}: {}".format(self.path, self.message)
 
 
 class SecretsNotAvailableError(Exception):
     """Raised when the secrets store was not accessible."""
 
     def __init__(self, inner):
-        super(SecretsNotAvailableError, self).__init__()
+        super(SecretsNotAvailableError, self).__init__(
+            "could not load secrets: {}".format(inner))
         self.inner = inner
-
-    def __str__(self):  # pragma: nocover
-        return "could not load secrets: {}".format(self.inner)
 
 
 _VersionedSecret = collections.namedtuple(
@@ -267,7 +261,7 @@ class SecretsStore(ContextFactory):
         self._load_if_needed()
         return self._data["vault"]["token"]
 
-    def make_object_for_context(self, name, server_span):  # pragma: nocover
+    def make_object_for_context(self, name, server_span):
         """Return an object that can be added to the context object.
 
         This allows the secret store to be used with

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,9 @@
 [nosetests]
-tests=tests/
+where=tests/
 with-coverage=1
 cover-package=baseplate
 cover-html=1
-cover-html-dir=build/coverage
+cover-html-dir=../build/coverage
 
 [flake8]
 ignore = E501,E128,E226

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -62,7 +62,7 @@ class TestSpanObserver(SpanObserver):
         self.on_finish_called = True
         self.on_finish_exc_info = exc_info
 
-    def on_child_span_created(self, span):  # pragma: nocover
+    def on_child_span_created(self, span):
         child = TestSpanObserver(span)
         self.children.append(child)
         span.register(child)

--- a/tests/unit/crypto_tests.py
+++ b/tests/unit/crypto_tests.py
@@ -59,6 +59,12 @@ class SignatureTests(unittest.TestCase):
         with self.assertRaises(crypto.UnreadableSignatureError):
             self.signer.validate_signature(self.message, signature[2:])
 
+    def test_invalid(self):
+        bad_signature = self.signer.make_signature(self.message + "bad", max_age=datetime.timedelta(seconds=30))
+
+        with self.assertRaises(crypto.IncorrectSignatureError):
+            self.signer.validate_signature(self.message, bad_signature)
+
     def test_signature_urlsafe(self):
         signature = self.signer.make_signature(self.message, max_age=datetime.timedelta(seconds=30))
         self.assertTrue(b"=" not in signature)


### PR DESCRIPTION
This does some maintenance on the test suite to improve coverage reporting and fix how we launch the suite so it's easier to use.

Rather than `nocover`ing the `__str__` implementations on exceptions, the messages are now pre-formatted during construction time and the base class `Exception`'s implementation of  `__str__` is used. This means we're sure the formatting doesn't crash without having to write tests that are tied to the specific output.