### PR TITLE
Add DictOf config parser

### DIFF
--- a/baseplate/__init__.py
+++ b/baseplate/__init__.py
@@ -36,7 +36,7 @@ def metrics_client_from_config(raw_config):
         },
     })
 
-    # pylint: disable=no-member
+    # pylint: disable=maybe-no-member
     return metrics.make_client(cfg.metrics.namespace, cfg.metrics.endpoint)
 
 
@@ -90,7 +90,7 @@ def tracing_client_from_config(raw_config, log_if_unconfigured=True):
         },
     })
 
-    # pylint: disable=no-member
+    # pylint: disable=maybe-no-member
     return tracing.make_client(
         service_name=cfg.tracing.service_name,
         tracing_endpoint=cfg.tracing.endpoint,
@@ -176,7 +176,7 @@ def error_reporter_from_config(raw_config, module_name):
         else:
             break
 
-    # pylint: disable=no-member
+    # pylint: disable=maybe-no-member
     return raven.Client(
         dsn=cfg.sentry.dsn,
         site=cfg.sentry.site,

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -254,7 +254,7 @@ def main():
         "secrets": config.Optional(config.TupleOf(config.String), default=[]),
     })
 
-    # pylint: disable=no-member
+    # pylint: disable=maybe-no-member
     client_factory = VaultClientFactory(cfg.vault.url, cfg.vault.role)
     while True:
         client = client_factory.get_client()

--- a/baseplate/secrets/store.py
+++ b/baseplate/secrets/store.py
@@ -269,5 +269,5 @@ def secrets_store_from_config(app_config):
             "path": config.Optional(config.String, default="/var/local/secrets.json"),
         },
     })
-    # pylint: disable=no-member
+    # pylint: disable=maybe-no-member
     return SecretsStore(cfg.secrets.path)

--- a/docs/baseplate/config.rst
+++ b/docs/baseplate/config.rst
@@ -25,12 +25,20 @@ make complicated expressions.
 .. autofunction:: Percent
 .. autofunction:: OneOf
 .. autofunction:: TupleOf
-.. autofunction:: Optional
-.. autofunction:: Fallback
 
 If you need something custom or fancy for your application, just use a
 callable which takes a string and returns the parsed value or raises
 :py:exc:`ValueError`.
+
+Combining Types
+---------------
+
+These options are used in combination with other types to form more complex
+configurations.
+
+.. autofunction:: Optional
+.. autofunction:: Fallback
+.. autofunction:: DictOf
 
 Data Types
 ----------

--- a/docs/config_dictof_example.ini
+++ b/docs/config_dictof_example.ini
@@ -1,0 +1,6 @@
+[app:main]
+population.cn = 1383890000
+population.in = 1317610000
+population.us = 325165000
+population.id = 263447000
+population.br = 207645000

--- a/docs/config_dictof_spec_example.ini
+++ b/docs/config_dictof_spec_example.ini
@@ -1,0 +1,11 @@
+[app:main]
+countries.cn.population = 1383890000
+countries.cn.capital = Beijing
+countries.in.population = 1317610000
+countries.in.capital = New Delhi
+countries.us.population = 325165000
+countries.us.capital = Washington D.C.
+countries.id.population = 263447000
+countries.id.capital = Jakarta
+countries.br.population = 207645000
+countries.br.capital = Brasília


### PR DESCRIPTION
This is useful for less static configuration, stuff that's closer to
data than basic configuration, which will likely be much more common
when we get live configuration abilities in Baseplate.

See the included docs for an example of usage.

I'm concerned about this parser being confusing since it takes multiple
keys instead of a single one. Maybe there's a better name than `DictOf`?
Maybe it'd be better to do a more complex syntax like requiring the key
in the config dict to be something like `"key.*": config.DictOf(...),`?