### PR TITLE
Add experiments and feature flags

### DIFF
--- a/baseplate/_compat.py
+++ b/baseplate/_compat.py
@@ -19,6 +19,10 @@ if sys.version_info.major == 3:  # pragma: nocover
     string_types = str,
     long = int
     import builtins
+
+    def iteritems(d):
+        return iter(d.items())
+
 else:  # pragma: nocover
     import ConfigParser as configparser
     import Queue as queue
@@ -31,6 +35,9 @@ else:  # pragma: nocover
     long = long
     BytesIO = StringIO
     import __builtin__ as builtins
+
+    def iteritems(d):
+        return d.iteritems()
 
 
 __all__ = [

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -80,3 +80,7 @@ class MetricsClientSpanObserver(SpanObserver):
         self.timer.stop()
         suffix = "success" if not exc_info else "failure"
         self.batch.counter(self.base_name + "." + suffix).increment()
+
+    def on_log(self, name, payload):
+        if name == "error.object":
+            self.batch.counter.increment("errors.%s" % payload.__class__.__name__)

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -1,0 +1,205 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+import logging
+
+from .providers import parse_experiment
+from .. import config
+from .._compat import iteritems
+from ..context import ContextFactory
+from ..events import Event, EventTooLargeError, EventQueueFullError
+from ..file_watcher import FileWatcher, WatchedFileNotAvailableError
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExperimentsContextFactory(ContextFactory):
+    """Experiment client context factory
+
+    This factory will attach a new :py:class:`baseplate.experiments.Experiments`
+    to an attribute on the :term:`context object`.
+    """
+    def __init__(self, path, event_queue):
+        """ExperimentContextFactory constructor
+
+        :param str path: Path to the experiment config file.
+        :param baseplate.events.EventQueue event_queue: Event queue used for
+            logging bucketing events to the event pipeline.  You can set this
+            to None to disable bucketing events entirely.
+        """
+        self._filewatcher = FileWatcher(path, json.load)
+        self._event_queue = event_queue
+
+    def make_object_for_context(self, name, server_span):
+        return Experiments(
+            config_watcher=self._filewatcher,
+            event_queue=self._event_queue,
+            server_span=server_span,
+            context_name=name,
+        )
+
+
+class Experiments(object):
+    """Access to experiments with automatic refresh when changed.
+
+    This experiments client allows access to the experiments cached on disk
+    by the experiment config fetcher daemon.  It will automatically reload
+    the cache when changed.  This client also handles logging bucketing events
+    to the event pipeline when it is determined that the request is part of an
+    active variant.
+    """
+
+    def __init__(self, config_watcher, event_queue, server_span, context_name):
+        self._config_watcher = config_watcher
+        self._event_queue = event_queue
+        self._span = server_span
+        self._context_name = context_name
+        self._already_bucketed = set()
+
+    def _get_config(self, name):
+        try:
+            config_data = self._config_watcher.get_data()
+            return config_data[name]
+        except WatchedFileNotAvailableError as exc:
+            logger.warning("Experiment config unavailable: %s", str(exc))
+            return
+        except KeyError:
+            logger.warning(
+                "Experiment <%r> not found in experiment config",
+                name,
+            )
+            return
+        except TypeError as exc:
+            logger.warning("Could not load experiment config: %s", str(exc))
+            return
+
+    def variant(self, name, bucketing_event_override=None,
+                extra_event_fields=None, **kwargs):
+        """Which variant, if any, is active.
+
+        If a variant is active, a bucketing event will be logged to the event
+        pipeline unless any one of the following conditions are met:
+
+        1. bucketing_event_override is set to False.
+        2. The experiment specified by "name" explicitly disables bucketing
+           events.
+        3. We have already logged a bucketing event for the value specified by
+           experiment.get_unique_id(\*\*kwargs) within the current
+           request.
+
+        Since checking the status an experiment will fire a bucketing event, it
+        is best to only check the variant when you are making the decision that
+        will expose the experiment to the user.  If you absolutely must check
+        the status of an experiment before you are sure that the experiment
+        will be exposed to the user, you can use `bucketing_event_override` to
+        disabled bucketing events for that check.
+
+        :param str name: Name of the experiment you want to run.
+        :param bool bucketing_event_override: (Optional) Set if you need to
+            override the default behavior for sending bucketing events.  This
+            parameter should be set sparingly as it breaks the assumption that
+            if you check a variant multiple times in a request, it will fire
+            one and only one bucketing event.  If set to True, will always log
+            bucketing events unless the experiment explicitly disables them,
+            even if a bucketing event has already been logged or the variant is
+            `None`.  If set to False, will never send a bucketing event. If set
+            to None, no override will be applied.  Set to None by default.
+        :param dict extra_event_fields: (Optional) Any extra fields you want to
+            add to the bucketing event.
+        :param kwargs:  Arguments that will be passed to experiment.variant to
+            determine bucketing, targeting, and overrides.
+
+        :rtype: :py:class:`str`
+        :return: Variant name if a variant is active, None otherwise.
+        """
+        experiment_config = self._get_config(name)
+        if not experiment_config:
+            return None
+
+        experiment = parse_experiment(experiment_config)
+        variant = experiment.variant(**kwargs)
+
+        do_log = True
+
+        if variant is None:
+            do_log = False
+
+        bucketing_id = experiment.get_unique_id(**kwargs)
+
+        if bucketing_id and bucketing_id in self._already_bucketed:
+            do_log = False
+
+        if bucketing_event_override is not None:
+            do_log = bool(bucketing_event_override)
+
+        do_log = do_log and experiment.should_log_bucketing()
+
+        if do_log:
+            self._log_bucketing_event(experiment, variant, extra_event_fields)
+            if bucketing_id:
+                self._already_bucketed.add(bucketing_id)
+
+        return variant
+
+    def _log_bucketing_event(self, experiment, variant, extra_event_fields):
+        if not self._event_queue:
+            return
+
+        extra_event_fields = extra_event_fields or {}
+
+        event_type = experiment.get_event_type()
+        if not event_type:
+            return
+
+        event = Event("bucketing_events", event_type)
+        for field, value in iteritems(extra_event_fields):
+            event.set_field(field, value)
+
+        event.set_field("variant", variant)
+        event.set_field("experiment_id", experiment.id)
+        event.set_field("experiment_name", experiment.name)
+        event.set_field("owner", experiment.owner)
+
+        span_name = "{}.{}".format(self._context_name, "events")
+        with self._span.make_child(span_name) as child_span:
+            try:
+                self._event_queue.put(event)
+            except EventTooLargeError as exc:
+                logger.warning(
+                    "The event payload was too large for the event queue."
+                )
+                child_span.set_tag("error", True)
+                child_span.log("error.object", exc)
+            except EventQueueFullError as exc:
+                logger.warning("The event queue is full.")
+                child_span.set_tag("error", True)
+                child_span.log("error.object", exc)
+
+
+def experiments_client_from_config(app_config, event_queue):
+    """Configure and return an :py:class:`ExperimentsContextFactory` object.
+
+    This expects one configuration option:
+
+    ``experiments.path``
+        The path to the experiment config file generated by the experiment
+        config fetcher daemon.
+
+    :param dict raw_config: The application configuration which should have
+        settings for the experiments client.
+    :param baseplate.events.EventQueue event_queue: The EventQueue to be used
+        to log bucketing events.
+    :rtype: :py:class:`ExperimentsContextFactory`
+
+    """
+    cfg = config.parse_config(app_config, {
+        "experiments": {
+            "path": config.Optional(config.String, default="/var/local/experiments.json"),
+        },
+    })
+    # pylint: disable=maybe-no-member
+    return ExperimentsContextFactory(cfg.experiments.path, event_queue)

--- a/baseplate/experiments/providers/__init__.py
+++ b/baseplate/experiments/providers/__init__.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+
+from datetime import datetime
+
+from .feature_flag import FeatureFlag
+from .forced_variant import ForcedVariantExperiment
+from .r2 import R2Experiment
+
+logger = logging.getLogger(__name__)
+
+
+ISO_DATE_FMT = "%Y-%d-%m"
+
+
+def parse_experiment(config):
+    """Factory method that parses an experiment config dict and returns an
+    appropriate Experiment class.
+
+    The config dict is expected to have the following values:
+
+        * **id**: Integer experiment ID, should be unique for each experiment.
+        * **name**: String experiment name, should be unique for each
+          experiment.
+        * **owner**: The group or individual that owns this experiment.
+        * **expires**: Date when this experiment expires in ISO format
+          (YYYY-MM-DD).  The experiment will expire at 00:00 UTC on the day
+          after the specified date.  Once an experiment is expired, it is
+          considered disabled.
+        * **type**: String specifying the type of experiment to run.  If this
+          value is not recognized, the experiment will be considered disabled.
+        * **experiment**: The experiment config dict for the specific type of
+          experiment.  The format of this is determined by the specific
+          experiment type.
+        * **enabled**:  (Optional) If set to False, the experiment will be
+          disabled and calls to experiment.variant will always return None and
+          will not log bucketing events to the event pipeline. Defaults to
+          True.
+        * **global_override**: (Optional) If this is set, calls to
+          experiment.variant will always return the override value and will not
+          log bucketing events to the event pipeline.
+
+    :param dict config: Configuration dict for the experiment you wish to run.
+    :rtype: :py:class:`baseplate.experiments.providers.base.Experiment`
+    :return: A subclass of :py:class:`Experiment` for the given experiment
+        type.
+    """
+    experiment_type = config["type"].lower()
+    experiment_id = config["id"]
+    assert isinstance(experiment_id, int)
+    name = config["name"]
+    owner = config.get("owner")
+    experiment_config = config["experiment"]
+    expiration = datetime.strptime(config["expires"], ISO_DATE_FMT).date()
+
+    if datetime.utcnow().date() > expiration:
+        return ForcedVariantExperiment(None)
+
+    enabled = config.get("enabled", True)
+    if not enabled:
+        return ForcedVariantExperiment(None)
+
+    if "global_override" in config:
+        # We want to check if "global_override" is in config rather than
+        # checking config.get("global_override") because global_override = None
+        # is a valid setting.
+        override = config.get("global_override")
+        return ForcedVariantExperiment(override)
+
+    if experiment_type == "r2":
+        return R2Experiment.from_dict(
+            id=experiment_id,
+            name=name,
+            owner=owner,
+            config=experiment_config,
+        )
+    elif experiment_type == "feature_flag":
+        return FeatureFlag.from_dict(
+            id=experiment_id,
+            name=name,
+            owner=owner,
+            config=experiment_config,
+        )
+    else:
+        logger.warning(
+            "Found an experiment <%s:%s> with an unknown experiment type <%s> "
+            "that is owned by <%s>. Please clean up.",
+            experiment_id,
+            name,
+            experiment_type,
+            owner,
+        )
+        return ForcedVariantExperiment(None)

--- a/baseplate/experiments/providers/base.py
+++ b/baseplate/experiments/providers/base.py
@@ -1,0 +1,47 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+
+class Experiment(object):
+    """Base interface for experiment objects. """
+
+    def get_unique_id(self, **kwargs):
+        """Generate a unique ID for this experiment with the given inputs.
+
+        Used to determine if a bucketing ivent has alread been fired for a
+        given experiment and bucketing value pair.  Returns None by default.
+        If None is returned, we will not mark that a bucketing event has been
+        logged even if we do log a bucketing event. The kwargs should be the
+        same values passed to the call to Experiment.variant.  If your
+        experiment does log bucketing events, you must implement this function.
+
+        :rtype: :py:class:`str` or None
+        """
+        if self.should_log_bucketing():
+            raise NotImplementedError
+        return None
+
+    def get_event_type(self):
+        if self.should_log_bucketing():
+            raise NotImplementedError
+        return None
+
+    def variant(self, **kwargs):
+        """Determine which variant, if any, of this experiment is active.
+
+        All arguments needed for bucketing, targeting, and variant overrides
+        should be passed in as kwargs.  The parameter names are determined by
+        the specific implementation of the Experiment interface.
+
+        :rtype: :py:class:`str`
+        :returns: The name of the enabled variant as a string if any variant is
+        enabled.  If no variant is enabled, return None.
+        """
+        raise NotImplementedError
+
+    def should_log_bucketing(self):
+        """Should this experiment log bucketing events to the event pipeline.
+        """
+        raise NotImplementedError

--- a/baseplate/experiments/providers/feature_flag.py
+++ b/baseplate/experiments/providers/feature_flag.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .r2 import R2Experiment
+
+
+class FeatureFlag(R2Experiment):
+    """An experiment with a single variant "active".
+
+    Does not log bucketing events to the event pipeline.  Use this type of
+    experiment if you just want to control access to a feature but do not want
+    to run an actual experiment.  Some examples for when you would want to use
+    a FeatureFlag are:
+
+    1. Slowly rolling out a new feature to a % of users
+    2. Restricting a new feature to certain subreddits
+
+    The config dict is expected to have the following values:
+
+        * **variants**: dict mapping variant names to their sizes. Variant
+          sizes are expressed as numeric percentages rather than a fraction of
+          1 (that is, 1.5 means 1.5%, not 150%).  For a feature flag, you can
+          only specify a single variant named "active".
+        * **targeting**: (Optional) dict that maps the names of targeting
+          parameters to lists of valid values.  When determining the variant
+          of an experiment, the targeting parameters you want to use are passed
+          in as keyword arguments to the call to experiment.variant.
+        * **overrides**: (Optional) dict that maps override parameters to
+          dictionaries mapping values to the variant name you want to override
+          the variant to. When determining the variant of an experiment, the
+          override parameters you want to use are passed in as keyword
+          arguments to the call to experiment.variant.
+        * **bucket_val**: (Optional) Name of the parameter you want to use for
+          bucketing.  This value must be passed to the call to
+          experiment.variant as a keyword argument.  Defaults to "user_id".
+        * **seed**: (Optional) Overrides the seed for this experiment.  If this
+          is not set, `name` is used as the seed.
+        * **newer_than**: (Optional) The earliest time that a bucketing
+          resource can have been created by in UTC epoch seconds.  If set, you
+          must pass the time, in UTC epoch seconds, when the resource that you
+          are bucketing was created to the call to experiment.variant as the
+          "created" parameter. For example, if you are bucketing based on
+          user_id, created would be set to the time when a User account was
+          created or when an LoID cookie was generated.
+
+    """
+
+    @classmethod
+    def from_dict(cls, id, name, owner, config):
+        variants = config.get("variants", {})
+        assert not set(variants.keys()) - {"active"}
+        return super(FeatureFlag, cls).from_dict(
+            id=id,
+            name=name,
+            owner=owner,
+            config=config,
+        )
+
+    def should_log_bucketing(self):
+        return False

--- a/baseplate/experiments/providers/forced_variant.py
+++ b/baseplate/experiments/providers/forced_variant.py
@@ -1,0 +1,25 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from .base import Experiment
+
+
+class ForcedVariantExperiment(Experiment):
+    """An experiment that always returns a specified variant.
+
+    Should not log bucketing events to the event pipeline.  Note that
+    ForcedVariantExperiments are not directly configured, rather they are
+    used when an experiment is disabled or when "global_override" is set in
+    the base config.
+    """
+
+    def __init__(self, variant):
+        self._variant = variant
+
+    def variant(self, **kwargs):
+        return self._variant
+
+    def should_log_bucketing(self):
+        return False

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -1,0 +1,315 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import hashlib
+
+from .base import Experiment
+from ..._compat import long, iteritems, string_types
+
+
+logger = logging.getLogger(__name__)
+
+
+class R2Experiment(Experiment):
+    """A "legacy", r2-style experiment.
+
+    Should log bucketing events to the event pipeline.
+
+    Note that this style of experiment caps the size of your variants such
+    that:
+
+    .. code-block:: python
+
+        def max_variant_size(variant_size, num_variants):
+            return max(variant_size, (1/num_variants) * 100)
+
+    The config dict is expected to have the following values:
+
+        * **variants**: dict mapping variant names to their sizes. Variant
+          sizes are expressed as numeric percentages rather than a fraction of
+          1 (that is, 1.5 means 1.5%, not 150%).
+        * **targeting**: (Optional) dict that maps the names of targeting
+          parameters to lists of valid values.  When determining the variant
+          of an experiment, the targeting parameters you want to use are passed
+          in as keyword arguments to the call to experiment.variant.
+        * **overrides**: (Optional) dict that maps override parameters to
+          dictionaries mapping values to the variant name you want to override
+          the variant to. When determining the variant of an experiment, the
+          override parameters you want to use are passed in as keyword
+          arguments to the call to experiment.variant.
+        * **bucket_val**: (Optional) Name of the parameter you want to use for
+          bucketing.  This value must be passed to the call to
+          experiment.variant as a keyword argument.  Defaults to "user_id".
+        * **seed**: (Optional) Overrides the seed for this experiment.  If this
+          is not set, `name` is used as the seed.
+        * **newer_than**: (Optional) The earliest time that a bucketing
+          resource can have been created by in UTC epoch seconds.  If set, you
+          must pass the time, in UTC epoch seconds, when the resource that you
+          are bucketing was created to the call to experiment.variant as the
+          "created" parameter. For example, if you are bucketing based on
+          user_id, created would be set to the time when a User account was
+          created or when an LoID cookie was generated.
+
+    """
+
+    def __init__(self, id, name, owner, variants, seed=None,
+                 bucket_val="user_id", targeting=None, overrides=None,
+                 newer_than=None):
+        targeting = dict(targeting or {})
+        overrides = dict(overrides or {})
+        self.targeting = {}
+        self.overrides = {}
+        self._case_sensitive_overrides = [
+            param_name.lower() for param_name in
+            overrides.pop("__case_sensitive__", [])
+        ]
+        self._case_sensitive_targeting = [
+            param_name.lower() for param_name in
+            targeting.pop("__case_sensitive__", [])
+        ]
+        for param, value in iteritems(targeting):
+            assert isinstance(param, string_types)
+            assert isinstance(value, list)
+            # even if the targeting parameter is case sensitive, the paramer
+            # name cannot be
+            key = param.lower()
+            self.targeting[param.lower()] = []
+            is_case_sensitive = key in self._case_sensitive_targeting
+            for v in value:
+                if is_case_sensitive or not isinstance(v, string_types):
+                    self.targeting[param.lower()].append(v)
+                else:
+                    self.targeting[param.lower()].append(v.lower())
+        for param, value in iteritems(overrides):
+            assert isinstance(param, string_types)
+            assert isinstance(value, dict)
+            # even if the override parameter is case sensitive, the paramer
+            # name cannot be
+            key = param.lower()
+            self.overrides[key] = {}
+            is_case_sensitive = key in self._case_sensitive_overrides
+            for k, v in iteritems(value):
+                if is_case_sensitive:
+                    override_val = k
+                else:
+                    override_val = k.lower()
+                self.overrides[key][override_val] = v
+        self.id = id
+        self.name = name
+        self.owner = owner
+        self.seed = seed if seed else name
+        self.num_buckets = 1000
+        self.variants = variants
+        self.bucket_val = bucket_val
+        self.newer_than = newer_than
+
+    @classmethod
+    def from_dict(cls, id, name, owner, config):
+        """Parse the config dict and return a new R2Experiment object.
+
+        :param int id: The id of the experiment from the base config.
+        :param str name: The name of the experiment from the base config.
+        :param str owner: The owner of the experiment from the base config.
+        :param dict config: The "experiment" config dict from the base config.
+        :rtype: :py:class:`baseplate.experiments.providers.r2.R2Experiment`
+        """
+        return cls(
+            id=id,
+            name=name,
+            owner=owner,
+            variants=config["variants"],
+            targeting=config.get("targeting"),
+            overrides=config.get("overrides"),
+            seed=config.get("seed"),
+            bucket_val=config.get("bucket_val", "user_id"),
+            newer_than=config.get("newer_than"),
+        )
+
+    def get_unique_id(self, **kwargs):
+        if kwargs.get(self.bucket_val):
+            return ":".join(
+                [self.name, self.bucket_val, str(kwargs[self.bucket_val])]
+            )
+        else:
+            return None
+
+    def get_event_type(self):
+        if self.bucket_val == "content_id":
+            return "bucket_page"
+        else:
+            return "bucket"
+
+    def should_log_bucketing(self):
+        return True
+
+    def variant(self, **kwargs):
+        lower_kwargs = {k.lower(): v for k, v in iteritems(kwargs)}
+        if self.bucket_val not in lower_kwargs:
+            logger.info(
+                "Must specify %s in call to variant for experiment %s.",
+                self.bucket_val,
+                self.name,
+            )
+            return None
+        if lower_kwargs[self.bucket_val] is None:
+            logger.info(
+                "Cannot choose a variant for bucket value %s = %s "
+                "for experiment %s.",
+                self.bucket_val,
+                lower_kwargs[self.bucket_val],
+                self.name,
+            )
+            return None
+
+        variant = self._check_overrides(**lower_kwargs)
+        if variant is not None and variant in self.variants:
+            return variant
+
+        if not self._is_enabled(**lower_kwargs):
+            return None
+
+        bucket = self._calculate_bucket(lower_kwargs[self.bucket_val])
+        return self._choose_variant(bucket)
+
+    def _check_overrides(self, **kwargs):
+        """Check if any of the kwargs override the variant. """
+        for override_arg in self.overrides:
+            if override_arg in kwargs:
+                values = kwargs[override_arg]
+                if not isinstance(values, (list, tuple)):
+                    values = [values]
+                for value in values:
+                    if not isinstance(value, string_types):
+                        final_value = value
+                    elif override_arg in self._case_sensitive_overrides:
+                        final_value = value
+                    else:
+                        final_value = value.lower()
+                    override = self.overrides[override_arg].get(final_value)
+                    if override is not None:
+                        return override
+        return None
+
+    def _is_enabled(self, **kwargs):
+        """Check if the targeting parameters in kwargs allow us to perform
+        the experiment.
+        """
+        for targeting_param, allowed_values in iteritems(self.targeting):
+            if targeting_param in kwargs:
+                targeting_values = kwargs[targeting_param]
+                if not isinstance(targeting_values, (list, tuple)):
+                    targeting_values = [targeting_values]
+                if not isinstance(allowed_values, list):
+                    allowed_values = [allowed_values]
+                for value in targeting_values:
+                    if not isinstance(value, string_types):
+                        final_value = value
+                    elif targeting_param in self._case_sensitive_targeting:
+                        final_value = value
+                    else:
+                        final_value = value.lower()
+                    if final_value in allowed_values:
+                        return True
+
+        user_created = kwargs.get("user_created")
+        if self.newer_than and user_created and user_created > self.newer_than:
+            return True
+
+        return False
+
+    def _calculate_bucket(self, bucket_val):
+        """Sort something into one of self.num_buckets buckets.
+
+        :param bucket_val -- a string used for shifting the deterministic bucketing
+                       algorithm.  In most cases, this will be an Account's
+                       _fullname.
+        :return int -- a bucket, 0 <= bucket < self.num_buckets
+        """
+        # Mix the experiment seed with the bucket_val so the same users don't
+        # get bucketed into the same bucket for each experiment.
+        seed_bytes = ("%s%s" % (self.seed, bucket_val)).encode()
+        hashed = hashlib.sha1(seed_bytes)
+        bucket = long(hashed.hexdigest(), 16) % self.num_buckets
+        return bucket
+
+    def _choose_variant(self, bucket):
+        """Deterministically choose a percentage-based variant.
+
+        The algorithm satisfies two conditions:
+
+        1. It's deterministic (that is, every call with the same bucket and
+           variants will result in the same answer).
+        2. An increase in any of the variant percentages will keep the same
+           buckets in the same variants as at the smaller percentage (that is,
+           all buckets previously put in variant A will still be in variant A,
+           all buckets previously put in variant B will still be in variant B,
+           etc. and the increased percentages will be made of up buckets
+           previously not assigned to a bucket).
+
+        These attributes make it suitable for use in A/B experiments that may
+        see an increase in their variant percentages post-enabling.
+
+        :param bucket -- an integer bucket representation
+        :param variants -- a dictionary of
+                           <string:variant name>:<float:percentage> pairs.  If
+                           any percentage exceeds 1/n percent, where n is the
+                           number of variants, the percentage will be capped to
+                           1/n.  These variants will be added to
+                           DEFAULT_CONTROL_GROUPS to create the effective
+                           variant set.
+        :return string -- the variant name, or None if bucket doesn't fall into
+                          any of the variants
+        """
+        # Say we have an experiment with two new things we're trying out for 2%
+        # of users (A and B), a control group with 5% (C), and a pool of
+        # excluded users (x).  The buckets will be assigned like so:
+        #
+        #     A B C A B C x x C x x C x x C x x x x x x x x x...
+        #
+        # This scheme allows us to later increase the size of A and B to 7%
+        # while keeping the experience consistent for users in any group other
+        # than excluded users:
+        #
+        #     A B C A B C A B C A B C A B C A B x A B x x x x...
+        #
+        # Rather than building this entire structure out in memory, we can use
+        # a little bit of math to figure out just the one bucket's value.
+        num_variants = len(self.variants)
+        variant_names = sorted(self.variants.keys())
+        # If the variants took up the entire set of buckets, which bucket would
+        # we be in?
+        candidate_variant = variant_names[bucket % num_variants]
+        # Log a warning if this variant is capped, to help us prevent user (us)
+        # error.  It's not the most correct to only check the one, but it's
+        # easy and quick, and anything with that high a percentage should be
+        # selected quite often.
+        variant_fraction = self.variants[candidate_variant] / 100.0
+        variant_cap = 1.0 / num_variants
+        if variant_fraction > variant_cap:
+            logger.warning(
+                'Variant %s exceeds allowable percentage (%.2f > %.2f)',
+                candidate_variant,
+                variant_fraction,
+                variant_cap,
+            )
+        # Variant percentages are expressed as numeric percentages rather than
+        # a fraction of 1 (that is, 1.5 means 1.5%, not 150%); thus, at 100
+        # buckets, buckets and percents map 1:1 with each other.  Since we may
+        # have more than 100 buckets (causing each bucket to represent less
+        # than 1% each), we need to scale up how far "right" we move for each
+        # variant percent.
+        bucket_multiplier = self.num_buckets / 100
+        # Now check to see if we're far enough left to be included in the
+        # variant percentage.
+        bucket_limit = (
+            self.variants[candidate_variant] *
+            num_variants *
+            bucket_multiplier
+        )
+        if bucket < bucket_limit:
+            return candidate_variant
+        else:
+            return None

--- a/docs/baseplate/experiments/feature_flag.rst
+++ b/docs/baseplate/experiments/feature_flag.rst
@@ -1,0 +1,9 @@
+``baseplate.experiments.providers.feature_flag``
+================================================
+
+.. automodule:: baseplate.experiments.providers.feature_flag
+
+Classes
+-------
+
+.. autoclass:: FeatureFlag

--- a/docs/baseplate/experiments/forced_variant.rst
+++ b/docs/baseplate/experiments/forced_variant.rst
@@ -1,0 +1,9 @@
+``baseplate.experiments.providers.forced_variant``
+===================================================
+
+.. automodule:: baseplate.experiments.providers.forced_variant
+
+Classes
+-------
+
+.. autoclass:: ForcedVariantExperiment

--- a/docs/baseplate/experiments/index.rst
+++ b/docs/baseplate/experiments/index.rst
@@ -1,0 +1,29 @@
+``baseplate.experiments``
+===============================
+
+.. automodule:: baseplate.experiments
+
+Experiment Providers
+--------------------
+
+.. toctree::
+   :titlesonly:
+
+   baseplate.experiments.providers.r2: Legacy, R2-style experiments <r2>
+   baseplate.experiments.providers.feature_flag: Feature Flag experiments <feature_flag>
+   baseplate.experiments.providers.forced_variant: Forced Variant experiment <forced_variant>
+
+Configuration Parsing
+---------------------
+
+.. autofunction:: baseplate.experiments.experiments_client_from_config
+
+.. autofunction:: baseplate.experiments.providers.parse_experiment
+
+Classes
+-------
+
+.. autoclass:: baseplate.experiments.ExperimentsContextFactory
+
+.. autoclass:: baseplate.experiments.Experiments
+   :members:

--- a/docs/baseplate/experiments/r2.rst
+++ b/docs/baseplate/experiments/r2.rst
@@ -1,0 +1,9 @@
+``baseplate.experiments.providers.r2``
+======================================
+
+.. automodule:: baseplate.experiments.providers.r2
+
+Classes
+-------
+
+.. autoclass:: R2Experiment

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,7 @@ separately from the rest of Baseplate.
    baseplate.config: Configuration parsing <baseplate/config>
    baseplate.crypto: Cryptographic Primitives <baseplate/crypto>
    baseplate.events: Events for the data pipeline <baseplate/events>
+   baseplate.experiments: Experiments framework <baseplate/experiments/index>
    baseplate.file_watcher: Read files from disk as they change <baseplate/file_watcher>
    baseplate.message_queue: POSIX IPC Message Queues <baseplate/message_queue>
    baseplate.metrics: Counters and timers for statsd <baseplate/metrics>

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -23,6 +23,8 @@ Redis
 serializable
 serialized
 serializer
+subreddit
+subreddits
 statsd
 sysctls
 unsampled

--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -47,6 +47,9 @@ class TracingTests(unittest.TestCase):
         self.server_span_observer = server_span_observer
 
     def setUp(self):
+        thread_patch = mock.patch("threading.Thread", autospec=True)
+        thread_patch.start()
+        self.addCleanup(thread_patch.stop)
         configurator = Configurator()
         configurator.add_route("example", "/example", request_method="GET")
         configurator.add_view(

--- a/tests/unit/diagnostics/tracing_tests.py
+++ b/tests/unit/diagnostics/tracing_tests.py
@@ -23,8 +23,17 @@ from baseplate.diagnostics.tracing import (
 from ... import mock
 
 
-class TraceObserverTests(unittest.TestCase):
+class TraceTestBase(unittest.TestCase):
+
     def setUp(self):
+        thread_patch = mock.patch("threading.Thread", autospec=True)
+        thread_patch.start()
+        self.addCleanup(thread_patch.stop)
+
+
+class TraceObserverTests(TraceTestBase):
+    def setUp(self):
+        super(TraceObserverTests, self).setUp()
         self.mock_context = mock.Mock()
 
     def test_null_recorder_setup(self):
@@ -145,8 +154,9 @@ class TraceObserverTests(unittest.TestCase):
         self.assertEqual(len(span.observers), 0)
 
 
-class TraceSpanObserverTests(unittest.TestCase):
+class TraceSpanObserverTests(TraceTestBase):
     def setUp(self):
+        super(TraceSpanObserverTests, self).setUp()
         self.recorder = NullRecorder()
         self.mock_context = mock.Mock()
 
@@ -244,8 +254,9 @@ class TraceSpanObserverTests(unittest.TestCase):
         self.assertEqual(span_obj['parentId'], 0)
 
 
-class TraceServerSpanObserverTests(unittest.TestCase):
+class TraceServerSpanObserverTests(TraceTestBase):
     def setUp(self):
+        super(TraceServerSpanObserverTests, self).setUp()
         self.recorder = NullRecorder()
         self.mock_context = mock.Mock()
         self.span = ServerSpan('test-id',
@@ -307,8 +318,9 @@ class TraceServerSpanObserverTests(unittest.TestCase):
         self.assertEqual(len(child_span.observers), 1)
         self.assertEqual(child_span.observers[0].span, child_span)
 
-class TraceLocalSpanObserverTests(unittest.TestCase):
+class TraceLocalSpanObserverTests(TraceTestBase):
     def setUp(self):
+        super(TraceLocalSpanObserverTests, self).setUp()
         self.recorder = NullRecorder()
         self.mock_context = mock.Mock()
         self.span = ServerSpan('test-id',
@@ -371,8 +383,9 @@ class TraceLocalSpanObserverTests(unittest.TestCase):
         self.assertEqual(lc_annotation['endpoint']['serviceName'], 'test-service')
         self.assertEqual(lc_annotation['value'], 'test-component')
 
-class NullRecorderTests(unittest.TestCase):
+class NullRecorderTests(TraceTestBase):
     def setUp(self):
+        super(NullRecorderTests, self).setUp()
         self.recorder = NullRecorder()
         self.mock_context = mock.Mock()
 
@@ -387,8 +400,9 @@ class NullRecorderTests(unittest.TestCase):
         self.recorder.flush_func([span])
 
 
-class RemoteRecorderTests(unittest.TestCase):
+class RemoteRecorderTests(TraceTestBase):
     def setUp(self):
+        super(RemoteRecorderTests, self).setUp()
         self.endpoint = "test:1111"
 
     def test_init(self):

--- a/tests/unit/experiments/experiment_tests.py
+++ b/tests/unit/experiments/experiment_tests.py
@@ -1,0 +1,290 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from datetime import datetime, timedelta
+
+from baseplate.core import ServerSpan
+from baseplate.events import EventQueue
+from baseplate.experiments import (
+    Experiments,
+    ExperimentsContextFactory,
+    experiments_client_from_config,
+)
+from baseplate.experiments.providers import ISO_DATE_FMT
+from baseplate.file_watcher import FileWatcher, WatchedFileNotAvailableError
+
+from ... import mock
+
+THIRTY_DAYS = timedelta(days=30)
+
+
+class TestExperiments(unittest.TestCase):
+
+    def setUp(self):
+        super(TestExperiments, self).setUp()
+        self.event_queue = mock.Mock(spec=EventQueue)
+        self.mock_filewatcher = mock.Mock(spec=FileWatcher)
+        self.mock_span = mock.MagicMock(spec=ServerSpan)
+        self.mock_span.trace_id = "123456"
+        self.user_id = "t2_1"
+        self.user_name = "gary"
+
+    def test_that_we_only_send_bucketing_event_once(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "id": 1,
+                    "name": "test",
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+
+        with mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.variant",
+            return_value="active",
+        ):
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 1)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 1)
+
+    def test_that_bucketing_events_are_always_sent_with_override_true(self):
+        """Send bucketing events on invalid requests with override"""
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+        with mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.variant",
+        ) as p:
+            p.return_value="active"
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=True)
+            self.assertEqual(self.event_queue.put.call_count, 1)
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=True)
+            self.assertEqual(self.event_queue.put.call_count, 2)
+            p.return_value = None
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=True)
+            self.assertEqual(self.event_queue.put.call_count, 3)
+
+    def test_that_bucketing_events_are_not_sent_with_override_false(self):
+        """Don't send events when override is False"""
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+        with mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.variant",
+        ) as p:
+            p.return_value="active"
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=False)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=False)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            p.return_value = None
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=False)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+
+    def test_that_bucketing_events_not_sent_if_no_variant(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+
+        with mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.variant",
+            return_value=None,
+        ):
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+
+    def test_that_bucketing_events_not_sent_if_experiment_disables(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+
+        with mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.variant",
+            return_value="active",
+        ), mock.patch(
+            "baseplate.experiments.providers.r2.R2Experiment.should_log_bucketing",
+            return_value=False,
+        ):
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+            experiments.variant("test", user_id=self.user_id,
+                                bucketing_event_override=True)
+            self.assertEqual(self.event_queue.put.call_count, 0)
+
+    def test_that_bucketing_events_not_sent_if_cant_load_config(self):
+        self.mock_filewatcher.get_data.side_effect = WatchedFileNotAvailableError("path", None)  # noqa
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+
+    def test_that_bucketing_events_not_sent_if_cant_parse_config(self):
+        self.mock_filewatcher.get_data.side_effect = TypeError()
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+
+    def test_that_bucketing_events_not_sent_if_cant_find_experiment(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "other_test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test",
+                "type": "r2",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "variants": {
+                        "active": 10,
+                        "control_1": 10,
+                        "control_2": 10,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            event_queue=self.event_queue,
+            server_span=self.mock_span,
+            context_name="test",
+        )
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id)
+        self.assertEqual(self.event_queue.put.call_count, 0)
+
+
+class ExperimentsClientFromConfigTests(unittest.TestCase):
+    def test_make_clients(self):
+        event_queue = mock.Mock(spec=EventQueue)
+        experiments = experiments_client_from_config({
+            "experiments.path": "/tmp/test",
+        }, event_queue)
+        self.assertIsInstance(experiments, ExperimentsContextFactory)

--- a/tests/unit/experiments/providers/feature_flag_tests.py
+++ b/tests/unit/experiments/providers/feature_flag_tests.py
@@ -1,0 +1,827 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import collections
+import time
+import unittest
+
+from datetime import datetime, timedelta
+
+from baseplate._compat import range
+from baseplate.core import ServerSpan
+from baseplate.events import EventQueue
+from baseplate.experiments import Experiments
+from baseplate.experiments.providers import ISO_DATE_FMT, parse_experiment
+from baseplate.file_watcher import FileWatcher
+
+from .... import mock
+
+logger = logging.getLogger(__name__)
+
+
+THIRTY_DAYS = timedelta(days=30)
+
+
+class TestFeatureFlag(unittest.TestCase):
+
+    def setUp(self):
+        super(TestFeatureFlag, self).setUp()
+        self.user_id = "t2_beef"
+        self.user_name = "gary"
+        self.user_logged_in = True
+
+    def _assert_fuzzy_percent_true(self, results, percent):
+        stats = collections.Counter(results)
+        total = sum(stats.values())
+        # _roughly_ `percent` should have been `True`
+        diff = abs((float(stats[True]) / total) - (percent / 100.0))
+        self.assertTrue(diff < 0.1)
+
+    def test_does_not_log_bucketing_event(self):
+        event_queue = mock.Mock(spec=EventQueue)
+        filewatcher = mock.Mock(spec=FileWatcher)
+        span = mock.MagicMock(spec=ServerSpan)
+        filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "type": "feature_flag",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "targeting": {
+                        "logged_in": [True, False],
+                    },
+                    "variants": {
+                        "active": 100,
+                    },
+                },
+            },
+        }
+        experiments = Experiments(
+            config_watcher=filewatcher,
+            event_queue=event_queue,
+            server_span=span,
+            context_name="test",
+        )
+        self.assertEqual(event_queue.put.call_count, 0)
+        variant = experiments.variant(
+            "test",
+            user_id=self.user_id,
+            logged_in=True,
+        )
+        self.assertEqual(variant, "active")
+        self.assertEqual(event_queue.put.call_count, 0)
+        experiments.variant("test", user_id=self.user_id, logged_in=True)
+        self.assertEqual(event_queue.put.call_count, 0)
+
+    def test_admin_enabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "admin": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+
+    def test_admin_disabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "admin": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=[],
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["beta"],
+        ), "active")
+
+    def test_employee_enabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "employee": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["employee"],
+        ), "active")
+
+    def test_employee_disabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "employee": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=[],
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["beta"],
+        ), "active")
+
+    def test_beta_enabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "beta": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["beta"],
+        ), "active")
+
+    def test_beta_disabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "beta": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=[],
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+
+    def test_gold_enabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "gold": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["gold"],
+        ), "active")
+
+    def test_gold_disabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "gold": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=[],
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+
+    def test_percent_loggedin(self):
+        num_users = 2000
+
+        def simulate_percent_loggedin(wanted_percent):
+            cfg = {
+                "id": 1,
+                "name": "test_feature",
+                "type": "feature_flag",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "targeting": {
+                        "logged_in": [True],
+                    },
+                    "variants": {
+                        "active": wanted_percent,
+                    },
+                },
+            }
+            feature_flag = parse_experiment(cfg)
+            return (
+                feature_flag.variant(
+                    user_id="t2_%s" % str(i),
+                    logged_in=True,
+                ) == "active" for i in range(num_users)
+            )
+
+        self.assertFalse(any(simulate_percent_loggedin(0)))
+        self.assertTrue(all(simulate_percent_loggedin(100)))
+        self._assert_fuzzy_percent_true(simulate_percent_loggedin(25), 25)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedin(10), 10)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedin(50), 50)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedin(99), 99)
+
+    def test_percent_loggedout(self):
+        num_users = 2000
+
+        def simulate_percent_loggedout(wanted_percent):
+            cfg = {
+                "id": 1,
+                "name": "test_feature",
+                "type": "feature_flag",
+                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "experiment": {
+                    "targeting": {
+                        "logged_in": [False],
+                    },
+                    "variants": {
+                        "active": wanted_percent,
+                    },
+                },
+            }
+            feature_flag = parse_experiment(cfg)
+            return (
+                feature_flag.variant(
+                    user_id="t2_%s" % str(i),
+                    logged_in=False,
+                ) == "active" for i in range(num_users)
+            )
+
+        self.assertFalse(any(simulate_percent_loggedout(0)))
+        self.assertTrue(all(simulate_percent_loggedout(100)))
+        self._assert_fuzzy_percent_true(simulate_percent_loggedout(25), 25)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedout(10), 10)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedout(50), 50)
+        self._assert_fuzzy_percent_true(simulate_percent_loggedout(99), 99)
+
+    def test_url_enabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "url_features": {
+                        "test_state": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            url_features=["test_state"],
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            url_features=["x", "test_state"],
+        ), "active")
+
+    def test_url_disabled(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "url_features": {
+                        "test_state": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            url_features=["x"],
+        ), "active")
+
+    def test_user_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_name": {
+                        "Gary": "active",
+                        "dave": "active",
+                        "ALL_UPPERCASE": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_name="Gary",
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_name=self.user_name,
+        ), "active")
+        all_uppercase_id = "t2_f00d"
+        all_uppercase_name = "ALL_UPPERCASE"
+        self.assertEqual(feature_flag.variant(
+            user_id=all_uppercase_id,
+            logged_in=True,
+            user_name=all_uppercase_name,
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=all_uppercase_id,
+            logged_in=True,
+            user_name=all_uppercase_name.lower(),
+        ), "active")
+
+    def test_user_not_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_name": {},
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_name=self.user_name,
+        ), "active")
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_name": {
+                        "dave": "active",
+                        "joe": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_name=self.user_name,
+        ), "active")
+
+    def test_subreddit_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subreddit": {
+                        "WTF": "active",
+                        "aww": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subreddit="WTF",
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subreddit="wtf",
+        ), "active")
+
+    def test_subreddit_not_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subreddit": {},
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subreddit="wtf",
+        ), "active")
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subreddit": {
+                        "wtfoobar": "active",
+                        "aww": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subreddit="wtf",
+        ), "active")
+
+    def test_subdomain_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subdomain": {
+                        "beta": "active",
+                        "www": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subdomain="beta",
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subdomain="BETA",
+        ), "active")
+
+    def test_subdomain_not_in(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subdomain": {},
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subdomain="beta",
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subdomain="",
+        ), "active")
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "subdomain": {
+                        "www": "active",
+                        "betanauts": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            subdomain="beta",
+        ), "active")
+
+    def test_multiple(self):
+        # is_admin, globally off should still be False
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "global_override": None,
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "admin": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+
+        # globally on but not admin should still be True
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "global_override": "active",
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "admin": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+
+        # no URL but admin should still be True
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_groups": {
+                        "admin": "active",
+                    },
+                    "url_features": {
+                        "test_featurestate": "active",
+                    },
+                },
+                "variants": {
+                    "active": 0,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_groups=["admin"],
+        ), "active")
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            url_features=["test_featurestate"],
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+
+    def test_is_newer_than(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "newer_than": int(time.time()) - THIRTY_DAYS.total_seconds(),
+                "variants": {
+                    "active": 100,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_created=int(time.time()),
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+
+    def test_is_not_newer_than(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "newer_than": int(time.time()) + THIRTY_DAYS.total_seconds(),
+                "variants": {
+                    "active": 100,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_created=int(time.time()),
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")

--- a/tests/unit/experiments/providers/forced_variant_tests.py
+++ b/tests/unit/experiments/providers/forced_variant_tests.py
@@ -1,0 +1,87 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import unittest
+
+from datetime import datetime, timedelta
+
+from baseplate.experiments.providers import ISO_DATE_FMT, parse_experiment
+from baseplate.experiments.providers.forced_variant import ForcedVariantExperiment
+
+THIRTY_DAYS = timedelta(days=30)
+
+
+class TestForcedVariantExperiment(unittest.TestCase):
+
+    def test_unknown_type_returns_null_experiment(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "unknown",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+        self.assertIs(experiment.variant(), None)
+        self.assertFalse(experiment.should_log_bucketing())
+
+    def test_global_override_returns_forced_variant(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "global_override": "foo",
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_disable_returns_forced_variant(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": False,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_forced_variant(self):
+        experiment = ForcedVariantExperiment("foo")
+        self.assertIs(experiment.variant(), "foo")
+        self.assertFalse(experiment.should_log_bucketing())
+
+    def test_forced_variant_null(self):
+        experiment = ForcedVariantExperiment(None)
+        self.assertIs(experiment.variant(), None)
+        self.assertFalse(experiment.should_log_bucketing())

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -1,0 +1,871 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import collections
+import math
+import unittest
+
+from datetime import datetime, timedelta
+
+from baseplate._compat import iteritems, long, range
+from baseplate.core import ServerSpan
+from baseplate.events import EventQueue
+from baseplate.experiments import ExperimentsContextFactory
+from baseplate.experiments.providers import ISO_DATE_FMT, parse_experiment
+from baseplate.experiments.providers.r2 import R2Experiment
+from baseplate.file_watcher import FileWatcher
+
+from .... import mock
+
+
+THIRTY_DAYS = timedelta(days=30)
+
+
+def get_users(num_users, logged_in=True):
+    users = []
+    for i in range(num_users):
+        if logged_in:
+            name = str(i)
+        else:
+            name = None
+        users.append(dict(
+            name=name,
+            id="t2_%s" % str(i),
+            logged_in=logged_in,
+        ))
+    return users
+
+
+def generate_content(num_content, content_type):
+    content = []
+
+    if content_type == "subreddit":
+        id_fmt = "t5_%s"
+    elif content_type == "link":
+        id_fmt = "t3_%s"
+    elif content_type == "comment":
+        id_fmt = "t1_%s"
+    else:
+        raise ValueError("Unknown content type: %s", content_type)
+
+    for i in range(num_content):
+        content.append(dict(id=id_fmt % i, type=content_type))
+
+    return content
+
+
+class TestR2Experiment(unittest.TestCase):
+
+    def test_r2_type_returns_r2_experiment(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, R2Experiment))
+        self.assertTrue(experiment.should_log_bucketing())
+
+    def test_calculate_bucket_value(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        experiment.num_buckets = 1000
+        self.assertEqual(experiment._calculate_bucket("t2_1"), long(236))
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "seed": "test-seed",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        seeded_experiment = parse_experiment(cfg)
+        self.assertNotEqual(seeded_experiment.seed, experiment.seed)
+        self.assertIsNot(seeded_experiment.seed, None)
+        seeded_experiment.num_buckets = 1000
+        self.assertEqual(
+            seeded_experiment._calculate_bucket("t2_1"),
+            long(595),
+        )
+
+    def test_calculate_bucket(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+
+        # Give ourselves enough users that we can get some reasonable amount of
+        # precision when checking amounts per bucket.
+        num_users = experiment.num_buckets * 1000
+        fullnames = []
+        for i in range(num_users):
+            fullnames.append("t2_%s" % str(i))
+
+        counter = collections.Counter()
+        for fullname in fullnames:
+            bucket = experiment._calculate_bucket(fullname)
+            counter[bucket] += 1
+            # Ensure bucketing is deterministic.
+            self.assertEqual(bucket, experiment._calculate_bucket(fullname))
+
+        for bucket in range(experiment.num_buckets):
+            # We want an even distribution across buckets.
+            expected = num_users / experiment.num_buckets
+            actual = counter[bucket]
+            # Calculating the percentage difference instead of looking at the
+            # raw difference scales better as we change num_users.
+            percent_equal = float(actual) / expected
+            self.assertAlmostEqual(percent_equal, 1.0, delta=.10,
+                                   msg='bucket: %s' % bucket)
+
+    def test_calculate_bucket_with_seed(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+                "seed": "itscoldintheoffice",
+            }
+        }
+        experiment = parse_experiment(cfg)
+
+        # Give ourselves enough users that we can get some reasonable amount of
+        # precision when checking amounts per bucket.
+        num_users = experiment.num_buckets * 1000
+        fullnames = []
+        for i in range(num_users):
+            fullnames.append("t2_%s" % str(i))
+
+        counter = collections.Counter()
+        bucketing_changed = False
+        for fullname in fullnames:
+            self.assertEqual(experiment.seed, "itscoldintheoffice")
+            bucket1 = experiment._calculate_bucket(fullname)
+            counter[bucket1] += 1
+            # Ensure bucketing is deterministic.
+            self.assertEqual(bucket1, experiment._calculate_bucket(fullname))
+
+            current_seed = experiment.seed
+            experiment.seed = "newstring"
+            bucket2 = experiment._calculate_bucket(fullname)
+            experiment.seed = current_seed
+            # check that the bucketing changed at some point. Can't compare
+            # bucket1 to bucket2 inline because sometimes the user will fall
+            # into both buckets, and test will fail
+            if bucket1 != bucket2:
+                bucketing_changed = True
+
+        self.assertTrue(bucketing_changed)
+
+        for bucket in range(experiment.num_buckets):
+            # We want an even distribution across buckets.
+            expected = num_users / experiment.num_buckets
+            actual = counter[bucket]
+            # Calculating the percentage difference instead of looking at the
+            # raw difference scales better as we change NUM_USERS.
+            percent_equal = float(actual) / expected
+            self.assertAlmostEqual(percent_equal, 1.0, delta=.10,
+                                   msg='bucket: %s' % bucket)
+
+    def test_choose_variant(self):
+        control_only = parse_experiment({
+            "id": 1,
+            "name": "control_only",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        })
+        three_variants = parse_experiment({
+            "id": 1,
+            "name": "three_variants",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    'remove_vote_counters': 5,
+                    'control_1': 10,
+                    'control_2': 5,
+                }
+            }
+        })
+        three_variants_more = parse_experiment({
+            "id": 1,
+            "name": "three_variants_more",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    'remove_vote_counters': 15.6,
+                    'control_1': 10,
+                    'control_2': 20,
+                }
+            }
+        })
+
+        counters = collections.defaultdict(collections.Counter)
+        for bucket in range(control_only.num_buckets):
+            variant = control_only._choose_variant(bucket)
+            if variant:
+                counters[control_only.name][variant] += 1
+            # Ensure variant-choosing is deterministic.
+            self.assertEqual(variant, control_only._choose_variant(bucket))
+
+            variant = three_variants._choose_variant(bucket)
+            if variant:
+                counters[three_variants.name][variant] += 1
+            # Ensure variant-choosing is deterministic.
+            self.assertEqual(variant, three_variants._choose_variant(bucket))
+
+            previous_variant = variant
+            variant = three_variants_more._choose_variant(bucket)
+            if variant:
+                counters[three_variants_more.name][variant] += 1
+            # Ensure variant-choosing is deterministic.
+            self.assertEqual(
+                variant,
+                three_variants_more._choose_variant(bucket)
+            )
+            # If previously we had a variant, we should still have the same one
+            # now.
+            if previous_variant:
+                self.assertEqual(variant, previous_variant)
+
+        for experiment in (control_only, three_variants, three_variants_more):
+            for variant, percentage in iteritems(experiment.variants):
+                count = counters[experiment.name][variant]
+                scaled_percentage = float(count) / (experiment.num_buckets / 100)
+                self.assertEqual(scaled_percentage, percentage)
+
+        # Test boundary conditions around the maximum percentage allowed for
+        # variants.
+        fifty_fifty = parse_experiment({
+            "id": 1,
+            "name": "fifty_fifty",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    'control_1': 50,
+                    'control_2': 50,
+                }
+            }
+        })
+        almost_fifty_fifty = parse_experiment({
+            "id": 1,
+            "name": "almost_fifty_fifty",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    'control_1': 49,
+                    'control_2': 51,
+                }
+            }
+        })
+        for bucket in range(fifty_fifty.num_buckets):
+            for experiment in (fifty_fifty, almost_fifty_fifty):
+                variant = experiment._choose_variant(bucket)
+                counters[experiment.name][variant] += 1
+
+        count = counters[fifty_fifty.name]['control_1']
+        scaled_percentage = float(count) / (fifty_fifty.num_buckets / 100)
+        self.assertEqual(scaled_percentage, 50)
+
+        count = counters[fifty_fifty.name]['control_2']
+        scaled_percentage = float(count) / (fifty_fifty.num_buckets / 100)
+        self.assertEqual(scaled_percentage, 50)
+
+        count = counters[almost_fifty_fifty.name]['control_1']
+        scaled_percentage = float(count) / (almost_fifty_fifty.num_buckets / 100)
+        self.assertEqual(scaled_percentage, 49)
+
+        count = counters[almost_fifty_fifty.name]['control_2']
+        scaled_percentage = float(count) / (almost_fifty_fifty.num_buckets / 100)
+        self.assertEqual(scaled_percentage, 50)
+
+
+class TestSimulatedR2Experiments(unittest.TestCase):
+
+    def setUp(self):
+        super(TestSimulatedR2Experiments, self).setUp()
+        self.event_queue = mock.Mock(spec=EventQueue)
+        self.mock_filewatcher = mock.Mock(spec=FileWatcher)
+        self.factory = ExperimentsContextFactory("path", self.event_queue)
+        self.factory._filewatcher = self.mock_filewatcher
+
+    def _simulate_experiment(self, config, static_vars, target_var, targets):
+        num_experiments = len(targets)
+        counter = collections.Counter()
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        for target in targets:
+            experiment_vars = {target_var: target}
+            experiment_vars.update(static_vars)
+            user = experiment_vars.pop("user")
+            content = experiment_vars.pop("content")
+            span = mock.MagicMock(spec=ServerSpan)
+            span.trace_id = "123456"
+            experiments = self.factory.make_object_for_context("test", span)
+            variant = experiments.variant(
+                config["name"],
+                user_id=user["id"],
+                user_name=user["name"],
+                logged_in=user["logged_in"],
+                content_id=content["id"],
+                content_type=content["type"],
+                **experiment_vars
+            )
+            if variant:
+                counter[variant] += 1
+
+        # this test will still probabilistically fail, but we can mitigate
+        # the likeliness of that happening
+        error_bar_percent = 100. / math.sqrt(num_experiments)
+        experiment = parse_experiment(config)
+        for variant, percent in iteritems(experiment.variants):
+            # Our actual percentage should be within our expected percent
+            # (expressed as a part of 100 rather than a fraction of 1)
+            # +- 1%.
+            measured_percent = (float(counter[variant]) / num_experiments) * 100
+            self.assertAlmostEqual(
+                measured_percent, percent, delta=error_bar_percent
+            )
+
+    def do_user_experiment_simulation(self, users, config, content=None):
+        content = content or dict(id=None, type=None)
+        static_vars = {
+            "content": content,
+            "url_params": {},
+            "subreddit": None,
+            "subdomain": None,
+        }
+        return self._simulate_experiment(
+            config=config,
+            static_vars=static_vars,
+            target_var="user",
+            targets=users,
+        )
+
+    def do_page_experiment_simulation(self, user, pages, config):
+        static_vars = {
+            "user": user,
+            "url_params": {},
+            "subreddit": None,
+            "subdomain": None,
+        }
+        return self._simulate_experiment(
+            config=config,
+            static_vars=static_vars,
+            target_var="content",
+            targets=pages,
+        )
+
+    def assert_no_user_experiment(self, users, config, content=None):
+        content = content or dict(id=None, type=None)
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        for user in users:
+            span = mock.MagicMock(spec=ServerSpan)
+            span.trace_id = "123456"
+            experiments = self.factory.make_object_for_context("test", span)
+            self.assertIs(
+                experiments.variant(
+                    config["name"],
+                    user_id=user["id"],
+                    user_name=user["name"],
+                    logged_in=user["logged_in"],
+                    content_id=content["id"],
+                    content_type=content["type"],
+                ), None
+            )
+
+    def assert_no_page_experiment(self, user, pages, config):
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        for page in pages:
+            span = mock.MagicMock(spec=ServerSpan)
+            span.trace_id = "123456"
+            experiments = self.factory.make_object_for_context("test", span)
+            self.assertIs(
+                experiments.variant(
+                    config["name"],
+                    user_id=user["id"],
+                    user_name=user["name"],
+                    logged_in=user["logged_in"],
+                    content_id=page["id"],
+                    content_type=page["type"],
+                ), None
+            )
+
+    def assert_same_variant(self, users, config, expected, content=None,
+                            **kwargs):
+        self.mock_filewatcher.get_data.return_value = {config["name"]: config}
+        content = content or dict(id=None, type=None)
+        for user in users:
+            span = mock.MagicMock(spec=ServerSpan)
+            span.trace_id = "123456"
+            experiments = self.factory.make_object_for_context("test", span)
+            self.assertEqual(
+                experiments.variant(
+                    config["name"],
+                    user_id=user["id"],
+                    user_name=user["name"],
+                    logged_in=user["logged_in"],
+                    content_id=content["id"],
+                    content_type=content["type"],
+                    **kwargs
+                ), expected
+            )
+
+    def test_experiment_overrides(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
+                "overrides": {
+                    "url_features": {
+                        "test_larger": "larger",
+                        "test_smaller": "smaller",
+                    },
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_same_variant(
+            users=get_users(2000),
+            config=config,
+            expected="larger",
+            url_features=["test_larger"],
+        )
+        self.assert_same_variant(
+            users=get_users(2000),
+            config=config,
+            expected="larger",
+            url_features=["test_larger", "test"],
+        )
+        self.assert_same_variant(
+            users=get_users(2000),
+            config=config,
+            expected="smaller",
+            url_features=["larger", "test_smaller"],
+        )
+        self.do_user_experiment_simulation(
+            users=get_users(2000),
+            config=config,
+        )
+
+    def test_loggedin_experiment(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_user_experiment_simulation(
+            users=get_users(2000),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+
+    def test_loggedin_experiment_explicit_enable(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": True,
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_user_experiment_simulation(
+            users=get_users(2000),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+
+    def test_loggedin_experiment_explicit_disable(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": False,
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_no_user_experiment(
+            users=get_users(2000),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+
+    def test_loggedout_experiment(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_user_experiment_simulation(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=True),
+            config=config,
+        )
+
+    def test_loggedout_experiment_missing_loids(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        users = get_users(2000, logged_in=False)
+        for user in users:
+            user["id"] = None
+        self.assert_no_user_experiment(
+            users=users,
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=True),
+            config=config,
+        )
+
+    def test_loggedout_experiment_explicit_enable(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": True,
+            "experiment": {
+                "targeting": {
+                    "logged_in": [False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_user_experiment_simulation(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=True),
+            config=config,
+        )
+
+    def test_loggedout_experiment_explicit_disable(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": False,
+            "experiment": {
+                "targeting": {
+                    "logged_in": [False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=True),
+            config=config,
+        )
+
+    def test_mixed_experiment(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True, False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_user_experiment_simulation(
+            users=get_users(1000) + get_users(1000, logged_in=False),
+            config=config,
+        )
+
+    def test_mixed_experiment_disable(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "enabled": False,
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True, False],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_no_user_experiment(
+            users=get_users(1000) + get_users(1000, logged_in=False),
+            config=config,
+        )
+
+    def test_not_loggedin_or_loggedout(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {},
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_no_user_experiment(
+            users=get_users(1000) + get_users(1000, logged_in=False),
+            config=config,
+        )
+
+    def test_subreddit_experiment(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "bucket_val": "content_id",
+                "targeting": {
+                    "content_type": ["subreddit"],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_page_experiment_simulation(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "subreddit"),
+            config=config,
+        )
+        self.assert_no_page_experiment(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "link"),
+            config=config,
+        )
+        self.assert_no_page_experiment(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "comment"),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(1000) + get_users(1000, logged_in=False),
+            config=config,
+        )
+
+    def test_link_experiment(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "bucket_val": "content_id",
+                "targeting": {
+                    "content_type": ["link", "comment"],
+                },
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.do_page_experiment_simulation(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "link"),
+            config=config,
+        )
+        self.do_page_experiment_simulation(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "comment"),
+            config=config,
+        )
+        self.assert_no_page_experiment(
+            user=get_users(1)[0],
+            pages=generate_content(2000, "subreddit"),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(1000) + get_users(1000, logged_in=False),
+            config=config,
+        )


### PR DESCRIPTION
This update ports the feature flag and experiment code from [r2](https://github.com/reddit/reddit/tree/master/r2/r2/config/feature) and their tests into baseplate.  Rather than just doing a straight port, this change attempts to:

1. Define a new, more extensible config format
2. Support for different experiment "providers" that can have different config formats and bucketing logic.
3. Formally separate feature flags from experiments
4. Remove un-used bits of code