### PR TITLE
Tracing exception handling

### DIFF
--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -14,6 +14,7 @@ import time
 from datetime import datetime
 
 import requests
+from requests.exceptions import RequestException
 
 from .._compat import queue
 from ..core import (
@@ -458,11 +459,14 @@ class RemoteRecorder(BaseBatchRecorder):
 
     def flush_func(self, spans):
         """Send a set of spans to remote collector."""
-        self.session.post(
-            self.endpoint,
-            data=json.dumps(spans),
-            headers={
-                'Content-Type': 'application/json',
-            },
-            timeout=1,
-        )
+        try:
+            self.session.post(
+                self.endpoint,
+                data=json.dumps(spans),
+                headers={
+                    'Content-Type': 'application/json',
+                },
+                timeout=1,
+            )
+        except RequestException as e:
+            self.logger.error("Error flushing spans: %s", e)

--- a/baseplate/diagnostics/tracing.py
+++ b/baseplate/diagnostics/tracing.py
@@ -116,7 +116,11 @@ class TraceBaseplateObserver(BaseplateObserver):
         self.service_name = tracing_client.service_name
         self.sample_rate = tracing_client.sample_rate
         self.recorder = tracing_client.recorder
-        self.hostname = socket.gethostbyname(socket.gethostname())
+        try:
+            self.hostname = socket.gethostbyname(socket.gethostname())
+        except socket.gaierror as e:
+            logger.error("Hostname could not be resolved, error=%s", e)
+            self.hostname = 'undefined'
 
     @classmethod
     def force_sampling(cls, span):


### PR DESCRIPTION
This contains two fixes for tracing-related exceptions so errors are handled more gracefully within Baseplate to avoid breaking services that enable tracing instrumentation. 

:eyeglasses: @spladug 