### PR TITLE
Add in alternative MessageQueue backed by redis

### DIFF
--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -5,7 +5,6 @@ from __future__ import unicode_literals
 
 import redis
 import redis.client
-import pickle
 from math import ceil
 
 from . import ContextFactory
@@ -188,18 +187,15 @@ class MessageQueue(object):
         else:
             message = self.client.blpop(self.queue, timeout=timeout)
 
-            if message:  # BLPOP returns a tuple of (key, value) and we just want value
-                message = message[1]
-
         if not message:
             raise message_queue.TimedOutError
 
-        return pickle.loads(message)
+        return message[1] if isinstance(message, tuple) else message
 
     def put(self, message, timeout=None):
         """Add a message to the queue.
         """
-        return self.client.rpush(self.queue, pickle.dumps(message))
+        return self.client.rpush(self.queue, message)
 
     def unlink(self):
         """Not implemented for redis variant

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -152,7 +152,7 @@ class MonitoredRedisPipeline(redis.client.StrictPipeline):
 
 
 class MessageQueue(object):
-    """A redis-backed variant of :py:class:`~baseplate.message_queue.MessageQueue`.
+    """A Redis-backed variant of :py:class:`~baseplate.message_queue.MessageQueue`.
 
     :param name: can be any string.
 
@@ -188,10 +188,13 @@ class MessageQueue(object):
         else:
             message = self.client.blpop(self.queue, timeout=timeout)
 
+            if message:
+                message = message[1]
+
         if not message:
             raise message_queue.TimedOutError
 
-        return message[1] if isinstance(message, tuple) else message
+        return message
 
     def put(self, message, timeout=None):
         """Add a message to the queue.
@@ -203,14 +206,14 @@ class MessageQueue(object):
         return self.client.rpush(self.queue, message)
 
     def unlink(self):
-        """Not implemented for redis variant
+        """Not implemented for Redis variant
         """
         pass
 
     def close(self):
         """Close queue when finished
 
-        Will delete the queue from the redis server (Note, can still enqueue
+        Will delete the queue from the Redis server (Note, can still enqueue
         and dequeue as the actions will recreate the queue)
         """
         self.client.delete(self.queue)

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import redis
 import redis.client
+import pickle
 from math import ceil
 
 from . import ContextFactory
@@ -187,15 +188,18 @@ class MessageQueue(object):
         else:
             message = self.client.blpop(self.queue, timeout=timeout)
 
+            if message:  # BLPOP returns a tuple of (key, value) and we just want value
+                message = message[1]
+
         if not message:
             raise message_queue.TimedOutError
 
-        return message[1] if isinstance(message, tuple) else message
+        return pickle.loads(message)
 
     def put(self, message, timeout=None):
         """Add a message to the queue.
         """
-        return self.client.rpush(self.queue, message)
+        return self.client.rpush(self.queue, pickle.dumps(message))
 
     def unlink(self):
         """Not implemented for redis variant

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -183,11 +183,16 @@ class MessageQueue(object):
         """
         if isinstance(timeout, float):
             timeout = int(ceil(timeout))
-        message = self.client.blpop(self.queue, timeout=timeout)
+
+        if timeout == 0:
+            message = self.client.lpop(self.queue)
+        else:
+            message = self.client.blpop(self.queue, timeout=timeout)
+
         if not message:
             raise message_queue.TimedOutError
 
-        return message[1]
+        return message[1] if isinstance(message, tuple) else message
 
     def put(self, message, timeout=None):
         """Add a message to the queue.

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -8,9 +8,7 @@ import redis.client
 from math import ceil
 
 from . import ContextFactory
-from .. import config
-
-from .. import message_queue
+from .. import config, message_queue
 
 
 def pool_from_config(app_config, prefix="redis.", **kwargs):
@@ -154,19 +152,19 @@ class MonitoredRedisPipeline(redis.client.StrictPipeline):
 
 
 class MessageQueue(object):
-    """A redis-backed variant of ``message_queue.MessageQueue``.
+    """A redis-backed variant of :py:class:`~baseplate.message_queue.MessageQueue`.
 
-    ``name`` can be any string.
+    :param ``name`` can be any string.
 
-    ``client`` should be a ``redis.ConnectionPool`` or
-    ``redis.BlockingConnectionPool`` from which a client connection can be
-    created from (preferrably generated from the ``pool_from_config`` helper).
+    :param ``client`` should be a :py:class:`redis.ConnectionPool` or
+    :py:class:`redis.BlockingConnectionPool` from which a client connection can be
+    created from (preferrably generated from the :py:func:`pool_from_config` helper).
 
     """
     def __init__(self, name, client):
         self.queue = name
-        if isinstance(client, redis.BlockingConnectionPool) \
-                or isinstance(client, redis.ConnectionPool):
+        if isinstance(client, redis.BlockingConnectionPool) or \
+                isinstance(client, redis.ConnectionPool):
             self.client = redis.Redis(connection_pool=client)
         else:
             self.client = client
@@ -206,6 +204,7 @@ class MessageQueue(object):
 
     def close(self):
         """Close queue when finished
+
         Will delete the queue from the redis server (Note, can still enqueue
         and dequeue as the actions will recreate the queue)
         """

--- a/baseplate/context/redis.py
+++ b/baseplate/context/redis.py
@@ -154,11 +154,12 @@ class MonitoredRedisPipeline(redis.client.StrictPipeline):
 class MessageQueue(object):
     """A redis-backed variant of :py:class:`~baseplate.message_queue.MessageQueue`.
 
-    :param ``name`` can be any string.
+    :param name: can be any string.
 
-    :param ``client`` should be a :py:class:`redis.ConnectionPool` or
-    :py:class:`redis.BlockingConnectionPool` from which a client connection can be
-    created from (preferrably generated from the :py:func:`pool_from_config` helper).
+    :param client: should be a :py:class:`redis.ConnectionPool` or
+           :py:class:`redis.BlockingConnectionPool` from which a client
+           connection can be created from (preferably generated from the
+           :py:func:`pool_from_config` helper).
 
     """
     def __init__(self, name, client):
@@ -194,6 +195,10 @@ class MessageQueue(object):
 
     def put(self, message, timeout=None):
         """Add a message to the queue.
+
+        :param message: will be typecast to a string upon storage and will come
+               out of the queue as a string regardless of what type they are
+               when passed into this method.
         """
         return self.client.rpush(self.queue, message)
 

--- a/docs/baseplate/context/redis.rst
+++ b/docs/baseplate/context/redis.rst
@@ -16,3 +16,6 @@ Classes
 
 .. autoclass:: baseplate.context.redis.MonitoredRedisConnection
    :members:
+
+.. autoclass:: baseplate.context.redis.MessageQueue
+   :members:

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -89,13 +89,15 @@ class RedisMessageQueueTests(unittest.TestCase):
             message = mq.get()
             self.assertEqual(message, b"x")
 
-    def test_put_get_richdatatype(self):
+    def test_get_timeout(self):
         message_queue = MessageQueue(self.qname, self.pool)
 
         with contextlib.closing(message_queue) as mq:
-            mq.put(("foo", "bar"))
-            message = mq.get()
-            self.assertEqual(message, ("foo", "bar"))
+            start = time.time()
+            with self.assertRaises(TimedOutError):
+                message_queue.get(timeout=1)
+            elapsed = time.time() - start
+            self.assertAlmostEqual(elapsed, 1.0, places=0)
 
     def test_get_zero_timeout(self):
         message_queue = MessageQueue(self.qname, self.pool)

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -89,15 +89,13 @@ class RedisMessageQueueTests(unittest.TestCase):
             message = mq.get()
             self.assertEqual(message, b"x")
 
-    def test_get_timeout(self):
+    def test_put_get_richdatatype(self):
         message_queue = MessageQueue(self.qname, self.pool)
 
         with contextlib.closing(message_queue) as mq:
-            start = time.time()
-            with self.assertRaises(TimedOutError):
-                message_queue.get(timeout=1)
-            elapsed = time.time() - start
-            self.assertAlmostEqual(elapsed, 1.0, places=0)
+            mq.put(("foo", "bar"))
+            message = mq.get()
+            self.assertEqual(message, ("foo", "bar"))
 
     def test_get_zero_timeout(self):
         message_queue = MessageQueue(self.qname, self.pool)

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -89,16 +89,6 @@ class RedisMessageQueueTests(unittest.TestCase):
             message = mq.get()
             self.assertEqual(message, b"x")
 
-    def test_get_timeout(self):
-        message_queue = MessageQueue(self.qname, self.pool)
-
-        with contextlib.closing(message_queue) as mq:
-            start = time.time()
-            with self.assertRaises(TimedOutError):
-                message_queue.get(timeout=1)
-            elapsed = time.time() - start
-            self.assertAlmostEqual(elapsed, 1.0, places=0)
-
     def test_get_zero_timeout(self):
         message_queue = MessageQueue(self.qname, self.pool)
 

--- a/tests/integration/redis_tests.py
+++ b/tests/integration/redis_tests.py
@@ -95,9 +95,19 @@ class RedisMessageQueueTests(unittest.TestCase):
         with contextlib.closing(message_queue) as mq:
             start = time.time()
             with self.assertRaises(TimedOutError):
-                mq.get(timeout=1)
+                message_queue.get(timeout=1)
             elapsed = time.time() - start
-            self.assertAlmostEqual(elapsed, 1.0, places=1)
+            self.assertAlmostEqual(elapsed, 1.0, places=0)
+
+    def test_get_zero_timeout(self):
+        message_queue = MessageQueue(self.qname, self.pool)
+
+        message_queue.put(b"y")
+        message = message_queue.get(timeout=0)
+        self.assertEqual(message, b"y")
+
+        with self.assertRaises(TimedOutError):
+            message_queue.get(timeout=0)
 
     def test_put_zero_timeout(self):
         message_queue = MessageQueue(self.qname, self.pool)


### PR DESCRIPTION
This offers an alternative `MessageQueue` handler that takes a Redis
pool and uses it for backing of the queue storage as opposed to the
POSIX system used normally.

Pros:
* Increased limits for queue size
* Some mechanism to back the queue up to disk (configuration dependent)
* No maximum limit for messages and message size
* No restriction on queue name (even supports empty strings as a key)

Cons:
* Blocking timeout behavior for reads is more restrictive
  (it uses the [`BLPOP`](https://redis.io/commands/blpop) which only allows
  integers for the seconds based timeout)
* More overhead before a timeout is issued compared to the POSIX variant