### PR TITLE
Remove navigation links from the sidebar

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,8 +76,6 @@ html_title = "Baseplate"
 html_sidebars = {
     "**": [
         "about.html",
-        "navigation.html",
-        "relations.html",
         "searchbox.html",
     ],
 }


### PR DESCRIPTION
They're pretty cluttered and not bringing much to the table. Some of the
longer titles are starting to mess with layout.

Before:

![before](https://user-images.githubusercontent.com/338853/28538797-5941cffa-7064-11e7-8524-7ab4d5243af9.png)

After:

![after](https://user-images.githubusercontent.com/338853/28538803-5f4a7b40-7064-11e7-846a-e32f145add3c.png)
