### PR TITLE
Add on_child_span_created listener to TraceLocalSpanObserver

### DIFF
--- a/tests/integration/tracing_tests.py
+++ b/tests/integration/tracing_tests.py
@@ -8,6 +8,7 @@ from baseplate import Baseplate
 from baseplate.diagnostics.tracing import (
     TraceBaseplateObserver,
     TraceServerSpanObserver,
+    TraceLocalSpanObserver,
     TraceSpanObserver,
     NullRecorder,
     RemoteRecorder,
@@ -35,16 +36,36 @@ def example_application(request):
         raise TestException("this is a test")
     return {"test": "success"}
 
+def local_parent_trace_within_context(request):
+    # For testing embedded tracing contexts
+    #  See `TracingTests.test_local_tracing_embedded`
+    with request.trace.make_child('local-req',
+                                  local=True,
+                                  component_name='in-context') as span:
+        with span.make_child('local-req',
+                             local=True,
+                             component_name='in-context') as child_span:
+            pass
 
 class TracingTests(unittest.TestCase):
 
-    def _register_mock(self, context, server_span):
+    def _register_server_mock(self, context, server_span):
         server_span_observer = TraceServerSpanObserver('test-service',
                                                        'test-hostname',
                                                        server_span,
                                                        NullRecorder())
         server_span.register(server_span_observer)
         self.server_span_observer = server_span_observer
+
+    def _register_local_mock(self, span):
+        local_span_observer = TraceLocalSpanObserver('test-service',
+                                                     'test-component',
+                                                     'test-hostname',
+                                                     span,
+                                                     NullRecorder())
+        self.local_span_ids.append(span.id)
+        self.local_span_observers.append(local_span_observer)
+        span.register(local_span_observer)
 
     def setUp(self):
         thread_patch = mock.patch("threading.Thread", autospec=True)
@@ -54,6 +75,10 @@ class TracingTests(unittest.TestCase):
         configurator.add_route("example", "/example", request_method="GET")
         configurator.add_view(
             example_application, route_name="example", renderer="json")
+
+        configurator.add_route("local_test", "/local_test", request_method="GET")
+        configurator.add_view(
+            local_parent_trace_within_context, route_name="local_test", renderer="json")
 
         self.client = make_client("test-service")
         self.observer = TraceBaseplateObserver(self.client)
@@ -67,17 +92,34 @@ class TracingTests(unittest.TestCase):
         )
         configurator.include(self.baseplate_configurator.includeme)
         app = configurator.make_wsgi_app()
+        self.local_span_ids = []
+        self.local_span_observers = []
         self.test_app = webtest.TestApp(app)
 
     def test_trace_on_inbound_request(self):
         with mock.patch.object(TraceBaseplateObserver, 'on_server_span_created',
-                               side_effect=self._register_mock) as mocked:
-
+                               side_effect=self._register_server_mock) as mocked:
             self.test_app.get('/example')
             span = self.server_span_observer._serialize()
             self.assertEqual(span['name'], 'example')
             self.assertEqual(len(span['annotations']), 2)
             self.assertEqual(span['parentId'], 0)
+
+    def test_local_tracing_embedded(self):
+        with mock.patch.object(TraceBaseplateObserver, 'on_server_span_created',
+                               side_effect=self._register_server_mock) as mocked, \
+             mock.patch.object(TraceServerSpanObserver, 'on_child_span_created',
+                               side_effect=self._register_local_mock) as server_child_mocked, \
+             mock.patch.object(TraceLocalSpanObserver, 'on_child_span_created',
+                               side_effect=self._register_local_mock) as local_child_mocked:
+
+            self.test_app.get('/local_test')
+            # Verify that child span can be created within a local span context
+            #  and parent IDs are inherited accordingly.
+            span = self.local_span_observers[-1]._serialize()
+            self.assertEqual(span['name'], 'local-req')
+            self.assertEqual(len(span['annotations']), 0)
+            self.assertEqual(span['parentId'], self.local_span_ids[-2])
 
     def test_configure_tracing_with_defaults_legacy_style(self):
         baseplate = Baseplate()


### PR DESCRIPTION
Per spec, child spans can be created within local spans, so local span
observers need to have a listener for that event and make sure
the child spans made within local spans are instrumented accordingly.

I think this bug got introduced with the restructuring of the span hierarchy. Since we need to differentiate the local vs non-local child span case, I've duplicated the method in the two subclasses of TraceSpanObserver (`TraceLocal` and `TraceServer`); an intermediate subclass would remove some duplicate code but I wanted to avoid adding complexity to the hierarchy for this small need. There might also be a need in the future to do more differentiating of handling child span creation in server vs local spans. 

:eyeglasses: @spladug @pacejackson 