### PR TITLE
Authentication context propagation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_install:
             python3-fbthrift \
             python3-gevent \
             python3-hvac \
+            python3-jwt \
             python3-kazoo \
             python3-nose \
             python3-posix-ipc \
@@ -49,11 +50,13 @@ before_install:
             python-alabaster \
             python-coverage \
             python-cqlmapper \
+            python-cryptography \
             python-enum34 \
             python-fbthrift \
             python-flake8 \
             python-gevent \
             python-hvac \
+            python-jwt \
             python-kazoo \
             python-mock \
             python-nose \

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -108,7 +108,7 @@ class PooledClientProxy(object):
                                 and span.context.authentication.token:
                             prot.trans.set_header(
                                 "Authentication",
-                                str(span.context.authentication)
+                                span.context.authentication.token
                             )
                         client = self.client_cls(prot)
                         method = getattr(client, name)

--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -104,6 +104,12 @@ class PooledClientProxy(object):
                             prot.trans.set_header("Sampled", sampled)
                         if span.flags:
                             prot.trans.set_header("Flags", str(span.flags))
+                        if hasattr(span.context, "authentication") \
+                                and span.context.authentication.token:
+                            prot.trans.set_header(
+                                "Authentication",
+                                str(span.context.authentication)
+                            )
                         client = self.client_cls(prot)
                         method = getattr(client, name)
                         return method(*args, **kwargs)

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -125,8 +125,7 @@ class TraceInfo(_TraceInfo):
 
 
 class AuthenticationContextFactory(object):
-    """Building factory for :py:class:`AuthenticationContext` objects, handles
-    context dependency for the secrets store.
+    """Factory for consistent AuthenticationContext creation.
 
     This factory should be passed into the constructor of any upstream
     :doc:`integrations <integration/index>` so that it is aware of the
@@ -140,9 +139,9 @@ class AuthenticationContextFactory(object):
         self.secrets = secrets_store
 
     def make_context(self, token):
-        """:py:class:`AuthenticationContext` builder
+        """Builds :py:class:`AuthenticationContext` using stored values
 
-        :param token: JWT value originating from the Authentication service
+        :param token: token value originating from the Authentication service
             either directly or from an upstream service
         :rtype: :py:class:`AuthenticationContext`
         """
@@ -152,7 +151,7 @@ class AuthenticationContextFactory(object):
 class AuthenticationContext(object):
     """Wrapper for the contextual authentication information
 
-    :param str token: the JWT value for the currently propagated authentication
+    :param str token: the value for the currently propagated authentication
         context
     :param baseplate.secrets.SecretsStore secrets_store: the application's
         defined secrets store, where application secret lookups should be made
@@ -238,29 +237,29 @@ class AuthenticationContext(object):
 
         return self.payload.get("sub", None)
 
-    def __str__(self):
-        return self.token if self.token else ""
-
 
 class UndefinedSecretsException(Exception):
-    """Exception raised when an :py:class:`AuthenticationContext` attempts to
-    parse an authentication JWT payload without having a
-    :py:class:`SecretsStore` defined to provide the necessary secrets values to
-    correctly decrypt and parse the token.
+    """Exception raised when no SecretsStore is defined during token parsing
+
+    Occurs in the :py:class:`AuthenticationContext` object when it attempts to
+    parse an authentication payload without having a :py:class:`SecretsStore`
+    defined to provide the necessary secrets values to correctly decrypt and
+    parse the token.
     """
     def __init__(self):
         super(UndefinedSecretsException, self).__init__(
-            "No SecretsStore defined.")
+            "No SecretsStore defined for Authentication token parsing.")
 
 
 class UndefinedAuthenticationError(Exception):
-    """Error raised when attempting to read from an authentication token that
-    is not defined, either because of a badly instantiated context or missing
-    header coming from upstream requests.
+    """Error raised when attempting to read from an unset authentication token
+
+    Occurs either because of a badly instantiated context or missing header
+    coming from upstream requests.
     """
     def __init__(self):
         super(UndefinedAuthenticationError, self).__init__(
-            "No Authentication JWT token provided for this context.")
+            "No Authentication token provided for this context.")
 
 
 class Baseplate(object):

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -81,8 +81,7 @@ class BaseplateConfigurator(object):
                  auth_factory=None):
         self.baseplate = baseplate
         self.trust_trace_headers = trust_trace_headers
-        self.auth_factory = auth_factory if auth_factory \
-            else AuthenticationContextFactory()
+        self.auth_factory = auth_factory or AuthenticationContextFactory()
 
     def _on_new_request(self, event):
         request = event.request
@@ -112,7 +111,7 @@ class BaseplateConfigurator(object):
                 authn_jwt = request.headers.get("X-Authentication", None)
                 authentication_context = \
                     self.auth_factory.make_context(authn_jwt)
-                request.authentication = authentication_context
+                authentication_context.attach_context(request)
             except (KeyError, ValueError):
                 pass
 

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -108,9 +108,9 @@ class BaseplateConfigurator(object):
                     flags=flags,
                 )
 
-                authn_jwt = request.headers.get("X-Authentication", None)
+                authn_token = request.headers.get("X-Authentication", None)
                 authentication_context = \
-                    self.auth_factory.make_context(authn_jwt)
+                    self.auth_factory.make_context(authn_token)
                 authentication_context.attach_context(request)
             except (KeyError, ValueError):
                 pass

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -26,7 +26,10 @@ import sys
 
 from thrift.Thrift import TProcessorEventHandler
 
-from ...core import TraceInfo
+from ...core import (
+    TraceInfo,
+    AuthenticationContextFactory,
+)
 
 
 class RequestContext(object):
@@ -41,11 +44,18 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
     :param logging.Logger logger: The logger to use for error and debug logging.
     :param baseplate.core.Baseplate baseplate: The baseplate instance for your
         application.
+    :param baseplate.core.AuthenticationContextFactory auth_factory: An
+        optional factory for authentication context building from incoming
+        request headers.  If not defined, a thin wrapper will be used to enable
+        passing the context downstream but will error out if attempted to be
+        used.
 
     """
-    def __init__(self, logger, baseplate):
+    def __init__(self, logger, baseplate, auth_factory=None):
         self.logger = logger
         self.baseplate = baseplate
+        self.auth_factory = auth_factory if auth_factory \
+            else AuthenticationContextFactory()
 
     def getHandlerContext(self, fn_name, server_context):
         context = RequestContext()
@@ -67,6 +77,10 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
                 sampled=sampled,
                 flags=flags,
             )
+
+            authn_jwt = headers.get(b"Authentication", None)
+            authentication_context = self.auth_factory.make_context(authn_jwt)
+            context.authentication = authentication_context
         except (KeyError, ValueError):
             pass
 

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -54,8 +54,7 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
     def __init__(self, logger, baseplate, auth_factory=None):
         self.logger = logger
         self.baseplate = baseplate
-        self.auth_factory = auth_factory if auth_factory \
-            else AuthenticationContextFactory()
+        self.auth_factory = auth_factory or AuthenticationContextFactory()
 
     def getHandlerContext(self, fn_name, server_context):
         context = RequestContext()
@@ -80,7 +79,7 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
 
             authn_jwt = headers.get(b"Authentication", None)
             authentication_context = self.auth_factory.make_context(authn_jwt)
-            context.authentication = authentication_context
+            authentication_context.attach_context(context)
         except (KeyError, ValueError):
             pass
 

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -77,8 +77,8 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
                 flags=flags,
             )
 
-            authn_jwt = headers.get(b"Authentication", None)
-            authentication_context = self.auth_factory.make_context(authn_jwt)
+            authn_token = headers.get(b"Authentication", None)
+            authentication_context = self.auth_factory.make_context(authn_token)
             authentication_context.attach_context(context)
         except (KeyError, ValueError):
             pass

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -61,10 +61,12 @@ integrations <integration/index>`.
 Authentication
 --------------
 
-If the application is dealing with authentication either directly from the
-authentication service or from upstream services, there are some support interfaces
-available for easily working with passing context down or picking up passed down
-contexts.
+If the application is directly receiving authentication from the authentication
+service or if it is receiving and wants to check authentication received from an
+upstream service, there are some support interfaces available for easily working
+with passing context down or picking up passed down contexts.  These helpers allow
+for the application to easily verify and access important values to ensure actions
+it is performing should be allowed in the current context.
 
 When receiving an initial authentication token from the authentication service, the
 application should properly store the token in an
@@ -73,7 +75,7 @@ context::
 
     authentication_token = retrieve_token_from_authentication_service()
     authentication_context = AuthenticationContext(authentication_token, secrets_store)
-    authentcation_context.attach_context(context)
+    authentication_context.attach_context(context)
 
 This will allow for this token to both be verified correctly and for the token to be
 passed downstream to other services that may need it.

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -58,6 +58,37 @@ integrations <integration/index>`.
 .. autoclass:: TraceInfo
    :members: from_upstream
 
+Authentication
+--------------
+
+If the application is dealing with authentication either directly from the
+authentication service or from upstream services, there are some support interfaces
+available for easily working with passing context down or picking up passed down
+contexts.
+
+When receiving an initial authentication token from the authentication service, the
+application should properly store the token in an
+:py:class:`~baseplate.core.AuthenticationContext` object attached to the current
+context::
+
+    authentication_token = retrieve_token_from_authentication_service()
+    context.authentication = AuthenticationContext(authentication_token, secrets_store)
+
+This will allow for this token to both be verified correctly and for the token to be
+passed downstream to other services that may need it.
+
+.. autoclass:: AuthenticationContextFactory
+   :members:
+
+.. autoclass:: AuthenticationContext
+   :members:
+
+.. autoclass:: UndefinedSecretsException
+   :members:
+
+.. autoclass:: UndefinedAuthenticationError
+   :members:
+
 Spans
 -----
 

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -72,7 +72,8 @@ application should properly store the token in an
 context::
 
     authentication_token = retrieve_token_from_authentication_service()
-    context.authentication = AuthenticationContext(authentication_token, secrets_store)
+    authentication_context = AuthenticationContext(authentication_token, secrets_store)
+    authentcation_context.attach_context(context)
 
 This will allow for this token to both be verified correctly and for the token to be
 passed downstream to other services that may need it.

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -89,7 +89,7 @@ passed downstream to other services that may need it.
 .. autoclass:: UndefinedSecretsException
    :members:
 
-.. autoclass:: UndefinedAuthenticationError
+.. autoclass:: WithheldAuthenticationError
    :members:
 
 Spans

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ PY3 = (sys.version_info.major == 3)
 install_requires = [
     "requests",
     "posix_ipc",
+    "pyjwt",
 ]
 
 tests_require = [

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -126,6 +126,7 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(server_span.id, 3456)
         self.assertEqual(server_span.sampled, True)
         self.assertEqual(server_span.flags, 1)
+        self.assertFalse(context.authentication.defined)
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
@@ -156,8 +157,7 @@ class ConfiguratorTests(unittest.TestCase):
             "X-Flags": "1",
         })
         context, _ = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(context.authentication.token, "invalid_but_doesnt_matter")
-
+        self.assertEqual(context.authentication._token, "invalid_but_doesnt_matter")
 
     def test_not_found(self):
         self.test_app.get("/nope", status=404)

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -8,7 +8,13 @@ from __future__ import print_function
 import unittest
 
 from baseplate import Baseplate
-from baseplate.core import BaseplateObserver, ServerSpanObserver
+from baseplate.core import (
+    BaseplateObserver,
+    ServerSpanObserver,
+    AuthenticationContextFactory,
+)
+from baseplate.file_watcher import FileWatcher
+from baseplate.secrets import store
 
 try:
     import webtest
@@ -40,6 +46,9 @@ def local_tracing_within_context(request):
     return {'trace': 'success'}
 
 class ConfiguratorTests(unittest.TestCase):
+    VALID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXJfaWQiLCJleHAiOjQ2NTY1OTM0NTV9.Q8bz2qccFOHLTQ6H3MPdjSh7wDkRQtbBuBwGMzNRKjDFSkCoVF5kiwhBUdwbW8UXO5iZn4Bh7oKdj69lIEOATUxFBblU8Do05EfjECXLYGdbr6ClNmldrB8SsdAtQYQ4Ud-70Z8_75QvkqX_TY5OA4asGJZwH9MC7oHey47-38I"
+    TOKEN_SECRET = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0Kd3qYtc6zI5tj3iKBux70BhE\nZLLJ7fAKNBUO7h9FCwUcYku+SFigzNOu3AAYt3seNgxl+cvMR2+SNwsa605J9D1v\n9eGmpcITQi85SeJnfR7LJUMu7RieY5wEl0RyuwnSkX3Gkv0+hZISC/XYcWEYolIi\n8725u7u/8HRtUeHoLwIDAQAB\n-----END PUBLIC KEY-----"
+
     def setUp(self):
         configurator = Configurator()
         configurator.add_route("example", "/example", request_method="GET")
@@ -50,6 +59,22 @@ class ConfiguratorTests(unittest.TestCase):
 
         configurator.add_view(
             local_tracing_within_context, route_name="trace_context", renderer="json")
+
+        mock_filewatcher = mock.Mock(spec=FileWatcher)
+        mock_filewatcher.get_data.return_value = {
+            "secrets": {
+                "jwt/authentication/secret": {
+                    "type": "simple",
+                    "value": self.TOKEN_SECRET,
+                },
+            },
+            "vault": {
+                "token": "test",
+                "url": "http://vault.example.com:8200/",
+            }
+        }
+        secrets = store.SecretsStore("/secrets")
+        secrets._filewatcher = mock_filewatcher
 
         self.observer = mock.Mock(spec=BaseplateObserver)
         self.server_observer = mock.Mock(spec=ServerSpanObserver)
@@ -62,6 +87,7 @@ class ConfiguratorTests(unittest.TestCase):
         self.baseplate_configurator = BaseplateConfigurator(
             self.baseplate,
             trust_trace_headers=True,
+            auth_factory=AuthenticationContextFactory(secrets),
         )
         configurator.include(self.baseplate_configurator.includeme)
         app = configurator.make_wsgi_app()
@@ -102,6 +128,31 @@ class ConfiguratorTests(unittest.TestCase):
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
+
+    def test_auth_headers(self):
+        self.test_app.get("/example", headers={
+            "X-Trace": "1234",
+            "X-Authentication": self.VALID_TOKEN,
+            "X-Parent": "2345",
+            "X-Span": "3456",
+            "X-Sampled": "1",
+            "X-Flags": "1",
+        })
+        context, _ = self.observer.on_server_span_created.call_args[0]
+        self.assertTrue(context.authentication.valid)
+        self.assertEqual(context.authentication.account_id, "test_user_id")
+
+    def test_blind_passthrough(self):
+        self.test_app.get("/example", headers={
+            "X-Trace": "1234",
+            "X-Authentication": "invalid_but_doesnt_matter",
+            "X-Parent": "2345",
+            "X-Span": "3456",
+            "X-Sampled": "1",
+            "X-Flags": "1",
+        })
+        context, _ = self.observer.on_server_span_created.call_args[0]
+        self.assertEqual(str(context.authentication), "invalid_but_doesnt_matter")
 
     def test_not_found(self):
         self.test_app.get("/nope", status=404)

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -11,7 +11,15 @@ try:
 except ImportError:
     from cStringIO import StringIO
 
-from baseplate.core import Baseplate, BaseplateObserver, ServerSpanObserver
+from baseplate.core import (
+    Baseplate,
+    BaseplateObserver,
+    ServerSpanObserver,
+    AuthenticationContextFactory,
+)
+from baseplate.file_watcher import FileWatcher
+from baseplate.secrets import store
+
 from baseplate.integration.thrift import BaseplateProcessorEventHandler
 
 from thrift.protocol.THeaderProtocol import THeaderProtocol
@@ -38,6 +46,9 @@ class TestHandler(TestService.ContextIface):
 
 
 class ThriftTests(unittest.TestCase):
+    VALID_TOKEN = b"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXJfaWQiLCJleHAiOjQ2NTY1OTM0NTV9.Q8bz2qccFOHLTQ6H3MPdjSh7wDkRQtbBuBwGMzNRKjDFSkCoVF5kiwhBUdwbW8UXO5iZn4Bh7oKdj69lIEOATUxFBblU8Do05EfjECXLYGdbr6ClNmldrB8SsdAtQYQ4Ud-70Z8_75QvkqX_TY5OA4asGJZwH9MC7oHey47-38I"
+    TOKEN_SECRET = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0Kd3qYtc6zI5tj3iKBux70BhE\nZLLJ7fAKNBUO7h9FCwUcYku+SFigzNOu3AAYt3seNgxl+cvMR2+SNwsa605J9D1v\n9eGmpcITQi85SeJnfR7LJUMu7RieY5wEl0RyuwnSkX3Gkv0+hZISC/XYcWEYolIi\n8725u7u/8HRtUeHoLwIDAQAB\n-----END PUBLIC KEY-----"
+
     def setUp(self):
         self.itrans = TMemoryBuffer()
         self.iprot = THeaderProtocol(self.itrans)
@@ -57,10 +68,28 @@ class ThriftTests(unittest.TestCase):
         self.server_context = TRpcConnectionContext(
             self.itrans, self.iprot, self.oprot)
 
+        mock_filewatcher = mock.Mock(spec=FileWatcher)
+        mock_filewatcher.get_data.return_value = {
+            "secrets": {
+                "jwt/authentication/secret": {
+                    "type": "simple",
+                    "value": self.TOKEN_SECRET,
+                },
+            },
+            "vault": {
+                "token": "test",
+                "url": "http://vault.example.com:8200/",
+            }
+        }
+        secrets = store.SecretsStore("/secrets")
+        secrets._filewatcher = mock_filewatcher
+
         baseplate = Baseplate()
         baseplate.register(self.observer)
 
-        event_handler = BaseplateProcessorEventHandler(self.logger, baseplate)
+        event_handler = BaseplateProcessorEventHandler(
+            self.logger, baseplate,
+            auth_factory=AuthenticationContextFactory(secrets))
 
         handler = TestHandler()
         self.processor = TestService.ContextProcessor(handler)
@@ -121,6 +150,30 @@ class ThriftTests(unittest.TestCase):
         self.assertEqual(self.server_observer.on_start.call_count, 1)
         self.assertEqual(self.server_observer.on_finish.call_count, 1)
         self.assertEqual(self.server_observer.on_finish.call_args[0], (None,))
+
+    def test_auth_headers(self):
+        client_memory_trans = TMemoryBuffer()
+        client_prot = THeaderProtocol(client_memory_trans)
+        client_header_trans = client_prot.trans
+        client_header_trans.set_header("Authentication", self.VALID_TOKEN)
+        client_header_trans.set_header("Trace", "1234")
+        client_header_trans.set_header("Parent", "2345")
+        client_header_trans.set_header("Span", "3456")
+        client_header_trans.set_header("Sampled", "1")
+        client_header_trans.set_header("Flags", "1")
+        client = TestService.Client(client_prot)
+        try:
+            client.example_simple()
+        except TTransportException:
+            pass  # we don't have a test response for the client
+        self.itrans._readBuffer = StringIO(client_memory_trans.getvalue())
+
+        self.processor.process(self.iprot, self.oprot, self.server_context)
+
+        context, _ = self.observer.on_server_span_created.call_args[0]
+
+        self.assertTrue(context.authentication.valid)
+        self.assertEqual(context.authentication.account_id, "test_user_id")
 
     def test_expected_exception_not_passed_to_server_span_finish(self):
         client_memory_trans = TMemoryBuffer()

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -147,6 +147,7 @@ class ThriftTests(unittest.TestCase):
         self.assertEqual(server_span.id, 3456)
         self.assertTrue(server_span.sampled)
         self.assertEqual(server_span.flags, 1)
+        self.assertFalse(context.authentication.defined)
 
         self.assertEqual(self.server_observer.on_start.call_count, 1)
         self.assertEqual(self.server_observer.on_finish.call_count, 1)

--- a/tests/integration/thrift_tests.py
+++ b/tests/integration/thrift_tests.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import logging
 import unittest
+import jwt
 
 try:
     from io import BytesIO as StringIO
@@ -172,8 +173,11 @@ class ThriftTests(unittest.TestCase):
 
         context, _ = self.observer.on_server_span_created.call_args[0]
 
-        self.assertTrue(context.authentication.valid)
-        self.assertEqual(context.authentication.account_id, "test_user_id")
+        try:
+            self.assertTrue(context.authentication.valid)
+            self.assertEqual(context.authentication.account_id, "test_user_id")
+        except jwt.exceptions.InvalidAlgorithmError:
+            raise unittest.SkipTest("cryptography is not installed")
 
     def test_expected_exception_not_passed_to_server_span_finish(self):
         client_memory_trans = TMemoryBuffer()

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -14,8 +14,13 @@ from baseplate.core import (
     Span,
     SpanObserver,
     TraceInfo,
+    AuthenticationContext,
+    UndefinedSecretsException,
+    UndefinedAuthenticationError,
 )
 from baseplate.integration import WrappedRequestContext
+from baseplate.file_watcher import FileWatcher
+from baseplate.secrets import store
 
 from .. import mock
 
@@ -226,3 +231,51 @@ class TraceInfoTests(unittest.TestCase):
         span = TraceInfo.from_upstream(1, 2, 3, None, None)
         self.assertIsNone(span.sampled)
         self.assertIsNone(span.flags)
+
+
+class AuthenticationContextTests(unittest.TestCase):
+    VALID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXJfaWQiLCJleHAiOjQ2NTY1OTM0NTV9.Q8bz2qccFOHLTQ6H3MPdjSh7wDkRQtbBuBwGMzNRKjDFSkCoVF5kiwhBUdwbW8UXO5iZn4Bh7oKdj69lIEOATUxFBblU8Do05EfjECXLYGdbr6ClNmldrB8SsdAtQYQ4Ud-70Z8_75QvkqX_TY5OA4asGJZwH9MC7oHey47-38I"
+    EXPIRED_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXJfaWQiLCJleHAiOjE1MDI5OTM3NTN9.OPBIxaOEx0hnnB_wrfCuqfSIeP0a1abNdoZ2KejXReKeETQathr-PW2GqAhjGcUdCG3rXK8ezFKXdlB65kloqNdQii5b3qaJ5PDIdMNxY0Oi7TAqH86oog_umm7G-_p4MPPhRjxUm6Qp85-EaJUgyv26BUKSYY7-KyySjnrmP8g"
+    TOKEN_SECRET = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0Kd3qYtc6zI5tj3iKBux70BhE\nZLLJ7fAKNBUO7h9FCwUcYku+SFigzNOu3AAYt3seNgxl+cvMR2+SNwsa605J9D1v\n9eGmpcITQi85SeJnfR7LJUMu7RieY5wEl0RyuwnSkX3Gkv0+hZISC/XYcWEYolIi\n8725u7u/8HRtUeHoLwIDAQAB\n-----END PUBLIC KEY-----"
+
+    def setUp(self):
+        mock_filewatcher = mock.Mock(spec=FileWatcher)
+        mock_filewatcher.get_data.return_value = {
+            "secrets": {
+                "jwt/authentication/secret": {
+                    "type": "simple",
+                    "value": self.TOKEN_SECRET,
+                },
+            },
+            "vault": {
+                "token": "test",
+                "url": "http://vault.example.com:8200/",
+            }
+        }
+        self.store = store.SecretsStore("/secrets")
+        self.store._filewatcher = mock_filewatcher
+
+    def test_empty_context(self):
+        new_auth_context = AuthenticationContext()
+        self.assertEqual(str(new_auth_context), "")
+
+    def test_no_secrets(self):
+        new_auth_context = AuthenticationContext("test token")
+        with self.assertRaises(UndefinedSecretsException) as e:
+            new_auth_context.valid
+
+    def test_valid_context(self):
+        new_auth_context = AuthenticationContext(self.VALID_TOKEN, self.store)
+        self.assertTrue(new_auth_context.valid)
+        self.assertEqual(new_auth_context.account_id, "test_user_id")
+
+    def test_expired_context(self):
+        new_auth_context = AuthenticationContext(self.EXPIRED_TOKEN, self.store)
+        self.assertFalse(new_auth_context.valid)
+        self.assertEqual(new_auth_context.account_id, None)
+
+    def test_no_context(self):
+        new_auth_context = AuthenticationContext(None, self.store)
+        self.assertEqual(new_auth_context.valid, None)
+        with self.assertRaises(UndefinedAuthenticationError) as e:
+            new_auth_context.account_id

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -17,7 +17,7 @@ from baseplate.core import (
     TraceInfo,
     AuthenticationContext,
     UndefinedSecretsException,
-    UndefinedAuthenticationError,
+    WithheldAuthenticationError,
 )
 from baseplate.integration import WrappedRequestContext
 from baseplate.file_watcher import FileWatcher
@@ -263,7 +263,7 @@ class AuthenticationContextTests(unittest.TestCase):
 
     def test_empty_context(self):
         new_auth_context = AuthenticationContext()
-        self.assertEqual(new_auth_context.token, None)
+        self.assertEqual(new_auth_context._token, None)
 
     def test_no_secrets(self):
         new_auth_context = AuthenticationContext("test token")
@@ -285,7 +285,8 @@ class AuthenticationContextTests(unittest.TestCase):
     @unittest.skipIf(not cryptography_installed, "cryptography not installed")
     def test_no_context(self):
         new_auth_context = AuthenticationContext(None, self.store)
-        self.assertEqual(new_auth_context.valid, None)
+        self.assertFalse(new_auth_context.defined)
+        self.assertFalse(new_auth_context.valid)
 
-        with self.assertRaises(UndefinedAuthenticationError) as e:
+        with self.assertRaises(WithheldAuthenticationError) as e:
             new_auth_context.account_id

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import unittest
+import jwt
 
 from baseplate.core import (
     Baseplate,
@@ -24,6 +25,11 @@ from baseplate.secrets import store
 
 from .. import mock
 
+cryptography_installed = True
+try:
+    import cryptography
+except:
+    cryptography_installed = False
 
 def make_test_server_span(context=None):
     if not context:
@@ -257,25 +263,29 @@ class AuthenticationContextTests(unittest.TestCase):
 
     def test_empty_context(self):
         new_auth_context = AuthenticationContext()
-        self.assertEqual(str(new_auth_context), "")
+        self.assertEqual(new_auth_context.token, None)
 
     def test_no_secrets(self):
         new_auth_context = AuthenticationContext("test token")
         with self.assertRaises(UndefinedSecretsException) as e:
             new_auth_context.valid
 
+    @unittest.skipIf(not cryptography_installed, "cryptography not installed")
     def test_valid_context(self):
         new_auth_context = AuthenticationContext(self.VALID_TOKEN, self.store)
         self.assertTrue(new_auth_context.valid)
         self.assertEqual(new_auth_context.account_id, "test_user_id")
 
+    @unittest.skipIf(not cryptography_installed, "cryptography not installed")
     def test_expired_context(self):
         new_auth_context = AuthenticationContext(self.EXPIRED_TOKEN, self.store)
         self.assertFalse(new_auth_context.valid)
         self.assertEqual(new_auth_context.account_id, None)
 
+    @unittest.skipIf(not cryptography_installed, "cryptography not installed")
     def test_no_context(self):
         new_auth_context = AuthenticationContext(None, self.store)
         self.assertEqual(new_auth_context.valid, None)
+
         with self.assertRaises(UndefinedAuthenticationError) as e:
             new_auth_context.account_id


### PR DESCRIPTION
Adds wrappers and handlers for retrieving propagated authentication information from upstream requests into an easy to use interface and standard system for further downstream propagation.  Overall the process is to convert the JWT payload received from the authentication service into an `AuthenticationContext` which can do validation and extraction, then store this is the current context and downstream requests via the built in thrift context will pull this value out of the current context and store the necessary information in a standard way for downstream services to easily and automatically retrieve.

There are some assumptions that may need to be refined, such as the way that the public RSA key for the authentication service is stored and retrieved, currently it is assumed (and hardcoded) to be in a `SecretStore` object under the simple key of `jwt/authentication/secret`.  Also, it is currently dependent on the originating service of the authentication to correctly package and define the information in the ongoing context for retrieval in the context handlers.  Any HTTP requests to downstream services will require the correct header be defined by hand (as there is no baseplate based HTTP client).