### PR TITLE
Experiment framework fixes and updates

### DIFF
--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -132,8 +132,9 @@ class Experiments(object):
         if experiment is None:
             return None
 
-        experiment = parse_experiment(experiment_config)
-        variant = experiment.variant(**kwargs)
+        span_name = "{}.{}".format(self._context_name, "variant")
+        with self._span.make_child(span_name, local=True, component_name=name):
+            variant = experiment.variant(**kwargs)
 
         do_log = True
 

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -163,11 +163,7 @@ class Experiments(object):
 
         extra_event_fields = extra_event_fields or {}
 
-        event_type = experiment.get_event_type()
-        if not event_type:
-            return
-
-        event = Event("bucketing_events", event_type)
+        event = Event("bucketing_events", "bucket")
         for field, value in iteritems(extra_event_fields):
             event.set_field(field, value)
 

--- a/baseplate/experiments/providers/base.py
+++ b/baseplate/experiments/providers/base.py
@@ -23,11 +23,6 @@ class Experiment(object):
             raise NotImplementedError
         return None
 
-    def get_event_type(self):
-        if self.should_log_bucketing():
-            raise NotImplementedError
-        return None
-
     def variant(self, **kwargs):
         """Determine which variant, if any, of this experiment is active.
 

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -141,6 +141,11 @@ class R2Experiment(Experiment):
 
     def variant(self, **kwargs):
         lower_kwargs = {k.lower(): v for k, v in iteritems(kwargs)}
+
+        variant = self._check_overrides(**lower_kwargs)
+        if variant is not None and variant in self.variants:
+            return variant
+
         if self.bucket_val not in lower_kwargs:
             logger.info(
                 "Must specify %s in call to variant for experiment %s.",
@@ -157,10 +162,6 @@ class R2Experiment(Experiment):
                 self.name,
             )
             return None
-
-        variant = self._check_overrides(**lower_kwargs)
-        if variant is not None and variant in self.variants:
-            return variant
 
         if not self._is_enabled(**lower_kwargs):
             return None

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -207,12 +207,14 @@ class R2Experiment(Experiment):
                     else:
                         final_value = value.lower()
                     if final_value in allowed_values:
-                        return True
+                        if targeting_param == "logged_in" and self.newer_than:
+                            user_created = kwargs.get("user_created")
+                            if (user_created and
+                                    user_created > self.newer_than):
+                                return True
 
-        user_created = kwargs.get("user_created")
-        if self.newer_than and user_created and user_created > self.newer_than:
-            return True
-
+                        else:
+                            return True
         return False
 
     def _calculate_bucket(self, bucket_val):

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -92,7 +92,7 @@ class R2Experiment(Experiment):
             self.overrides[key] = {}
             is_case_sensitive = key in self._case_sensitive_overrides
             for k, v in iteritems(value):
-                if is_case_sensitive:
+                if is_case_sensitive or not isinstance(k, string_types):
                     override_val = k
                 else:
                     override_val = k.lower()

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -136,12 +136,6 @@ class R2Experiment(Experiment):
         else:
             return None
 
-    def get_event_type(self):
-        if self.bucket_val == "content_id":
-            return "bucket_page"
-        else:
-            return "bucket"
-
     def should_log_bucketing(self):
         return True
 

--- a/tests/unit/experiments/experiment_tests.py
+++ b/tests/unit/experiments/experiment_tests.py
@@ -69,8 +69,7 @@ class TestExperiments(unittest.TestCase):
             experiments.variant("test", user_id=self.user_id)
             self.assertEqual(self.event_queue.put.call_count, 1)
 
-    def test_that_bucketing_events_are_always_sent_with_override_true(self):
-        """Send bucketing events on invalid requests with override"""
+    def test_that_override_true_has_no_effect(self):
         self.mock_filewatcher.get_data.return_value = {
             "test": {
                 "id": 1,
@@ -103,11 +102,7 @@ class TestExperiments(unittest.TestCase):
             self.assertEqual(self.event_queue.put.call_count, 1)
             experiments.variant("test", user_id=self.user_id,
                                 bucketing_event_override=True)
-            self.assertEqual(self.event_queue.put.call_count, 2)
-            p.return_value = None
-            experiments.variant("test", user_id=self.user_id,
-                                bucketing_event_override=True)
-            self.assertEqual(self.event_queue.put.call_count, 3)
+            self.assertEqual(self.event_queue.put.call_count, 1)
 
     def test_that_bucketing_events_are_not_sent_with_override_false(self):
         """Don't send events when override is False"""

--- a/tests/unit/experiments/providers/feature_flag_tests.py
+++ b/tests/unit/experiments/providers/feature_flag_tests.py
@@ -785,6 +785,9 @@ class TestFeatureFlag(unittest.TestCase):
             "type": "feature_flag",
             "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
             "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
                 "newer_than": int(time.time()) - THIRTY_DAYS.total_seconds(),
                 "variants": {
                     "active": 100,
@@ -809,6 +812,9 @@ class TestFeatureFlag(unittest.TestCase):
             "type": "feature_flag",
             "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
             "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                },
                 "newer_than": int(time.time()) + THIRTY_DAYS.total_seconds(),
                 "variants": {
                     "active": 100,
@@ -820,6 +826,35 @@ class TestFeatureFlag(unittest.TestCase):
             user_id=self.user_id,
             logged_in=self.user_logged_in,
             user_created=int(time.time()),
+        ), "active")
+        self.assertNotEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+        ), "active")
+
+
+    def test_newer_than_only_on_logged_in_check(self):
+        cfg = {
+            "id": 1,
+            "name": "test_feature",
+            "type": "feature_flag",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "targeting": {
+                    "logged_in": [True],
+                    "user_name": ["gary"],
+                },
+                "newer_than": int(time.time()) + THIRTY_DAYS.total_seconds(),
+                "variants": {
+                    "active": 100,
+                },
+            },
+        }
+        feature_flag = parse_experiment(cfg)
+        self.assertEqual(feature_flag.variant(
+            user_id=self.user_id,
+            logged_in=self.user_logged_in,
+            user_name="gary",
         ), "active")
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -564,6 +564,31 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             config=config,
         )
 
+    def test_no_targeting_no_variant(self):
+        config = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "variants": {
+                    "larger": 5,
+                    "smaller": 10,
+                    "control_1": 10,
+                    "control_2": 10,
+                },
+            },
+        }
+        self.assert_no_user_experiment(
+            users=get_users(2000),
+            config=config,
+        )
+        self.assert_no_user_experiment(
+            users=get_users(2000, logged_in=False),
+            config=config,
+        )
+
     def test_loggedin_experiment(self):
         config = {
             "id": 1,

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -337,6 +337,29 @@ class TestR2Experiment(unittest.TestCase):
         scaled_percentage = float(count) / (almost_fifty_fifty.num_buckets / 100)
         self.assertEqual(scaled_percentage, 50)
 
+    def test_non_string_override_value(self):
+        experiment = parse_experiment({
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "logged_in": {
+                        True: "active",
+                    },
+                },
+                "variants": {
+                    'active': 10,
+                    'control_1': 10,
+                    'control_2': 20,
+                }
+            }
+        })
+        variant = experiment.variant(logged_in=True)
+        self.assertEqual(variant, "active")
+
 
 class TestSimulatedR2Experiments(unittest.TestCase):
 

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -337,6 +337,31 @@ class TestR2Experiment(unittest.TestCase):
         scaled_percentage = float(count) / (almost_fifty_fifty.num_buckets / 100)
         self.assertEqual(scaled_percentage, 50)
 
+    def test_return_override_variant_without_bucket_val(self):
+        experiment = parse_experiment({
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "experiment": {
+                "overrides": {
+                    "user_name": {
+                        "gary": "active",
+                    },
+                },
+                "variants": {
+                    'active': 10,
+                    'control_1': 10,
+                    'control_2': 20,
+                }
+            }
+        })
+        variant = experiment.variant(user_name="gary")
+        self.assertEqual(variant, "active")
+        variant = experiment.variant()
+        self.assertEqual(variant, None)
+
     def test_non_string_override_value(self):
         experiment = parse_experiment({
             "id": 1,


### PR DESCRIPTION
# Fixes

1. Allow non-string override values.
2. Handle `newer_than` correctly.  Should only check `newer_than` as a part of checking the `logged_id` targeting value.
3. Check overrides before checking the bucket_val.
4. Update the bucketing logic to better match what we do in r2.

# Updates

1. Remove `get_event_type` from experiments.
2. Cache the parsed `Experiment` objects in the `Experiments` client object.
3. Add tests for the fixes.