### PR TITLE
Request context

### DIFF
--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -106,11 +106,18 @@ class PooledClientProxy(object):
                             prot.trans.set_header("Flags", str(span.flags))
 
                         try:
-                            auth_token = span.context.authentication.token
+                            context_headers = span.context.request_context.header_values()
                         except AttributeError:
                             pass
                         else:
-                            prot.trans.set_header("Authentication", auth_token)
+                            prot.trans.set_header(
+                                "Authentication",
+                                context_headers.get("Authentication"),
+                            )
+                            prot.trans.set_header(
+                                "Edge-Request",
+                                context_headers.get("Edge-Request"),
+                            )
 
                         client = self.client_cls(prot)
                         method = getattr(client, name)

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -238,6 +238,63 @@ class AuthenticationContext(object):
 
         return self.payload.get("sub", None)
 
+    @property
+    def user_roles(self):
+        """User roles for the current authenticated context
+
+        :type: set(string)
+        :raises: :py:class:`UndefinedSecretsException` if the
+            :py:class:`SecretsStore` has not been bound to the context handling
+            class (means that the authentication payload could not be decrypted
+            and the user_id returned)
+        :raises: :py:class:`WithheldAuthenticationError` if there was no
+            authentication token defined for the current context
+
+        """
+        if not self.defined:
+            raise WithheldAuthenticationError
+
+        roles = self.payload.get("user_roles", None)
+        return set(roles) if roles else set()
+
+    @property
+    def oauth_client_id(self):
+        """ID for the OAuth client used with the current authenticated context
+
+        :type: string or None if context authentication is invalid or the user
+            did not authenticate with OAuth2
+        :raises: :py:class:`UndefinedSecretsException` if the
+            :py:class:`SecretsStore` has not been bound to the context handling
+            class (means that the authentication payload could not be decrypted
+            and the user_id returned)
+        :raises: :py:class:`WithheldAuthenticationError` if there was no
+            authentication token defined for the current context
+
+        """
+        if not self.defined:
+            raise WithheldAuthenticationError
+
+        return self.payload.get("client_id", None)
+
+    @property
+    def oauth_client_type(self):
+        """Type of OAuth client used with the current authenticated context
+
+        :type: string or None if context authentication is invalid or the user
+            did not authenticate with OAuth2
+        :raises: :py:class:`UndefinedSecretsException` if the
+            :py:class:`SecretsStore` has not been bound to the context handling
+            class (means that the authentication payload could not be decrypted
+            and the user_id returned)
+        :raises: :py:class:`WithheldAuthenticationError` if there was no
+            authentication token defined for the current context
+
+        """
+        if not self.defined:
+            raise WithheldAuthenticationError
+
+        return self.payload.get("client_type", None)
+
 
 class UndefinedSecretsException(Exception):
     """Exception raised when no SecretsStore is defined during token parsing

--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -161,6 +161,9 @@ class AuthenticationContextFactory(object):
 class AuthenticationContext(object):
     """Wrapper for the contextual authentication information
 
+    In general, this object should not be used directly but will rather be
+    wrapped by an :py:class:`EdgeRequestContext` object.
+
     :param str token: the value for the currently propagated authentication
         context
     :param baseplate.secrets.SecretsStore secrets_store: the application's
@@ -180,7 +183,14 @@ class AuthenticationContext(object):
         return self._secret_store.get_simple("jwt/authentication/secret")
 
     def attach_context(self, context):
-        """Attach this authentication wrapper to the provided context
+        """.. deprecated:: 0.23.0
+
+        Attaching the AuthenticationContext object to the context directly is
+        considered deprecated.  You should be passing the AuthenticationContext
+        object to the EdgeRequestContext constructor and attaching that object
+        to the context.  Baseplate will only forward the AuthenticationContext
+        if it is included in the EdgeRequestContext object that is attached to
+        the context object.
 
         :param context: request context to attach this authentication to
 

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -31,6 +31,7 @@ import pyramid.tweens
 
 from ..core import (
     TraceInfo,
+    EdgeRequestContext,
     AuthenticationContextFactory,
 )
 from ..server import make_app
@@ -109,9 +110,16 @@ class BaseplateConfigurator(object):
                 )
 
                 authn_token = request.headers.get("X-Authentication", None)
+                request_context_payload = request.headers.get("X-Edge-Request",
+                                                              None)
                 authentication_context = \
                     self.auth_factory.make_context(authn_token)
                 authentication_context.attach_context(request)
+                request_context = EdgeRequestContext(
+                    header=request_context_payload,
+                    authentication_context=authentication_context,
+                )
+                request_context.attach_context(request)
             except (KeyError, ValueError):
                 pass
 

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -28,6 +28,7 @@ from thrift.Thrift import TProcessorEventHandler
 
 from ...core import (
     TraceInfo,
+    EdgeRequestContext,
     AuthenticationContextFactory,
 )
 
@@ -78,8 +79,14 @@ class BaseplateProcessorEventHandler(TProcessorEventHandler):
             )
 
             authn_token = headers.get(b"Authentication", None)
+            request_context_payload = headers.get(b"Edge-Request", None)
             authentication_context = self.auth_factory.make_context(authn_token)
             authentication_context.attach_context(context)
+            request_context = EdgeRequestContext(
+                header=request_context_payload,
+                authentication_context=authentication_context,
+            )
+            request_context.attach_context(context)
         except (KeyError, ValueError):
             pass
 

--- a/baseplate/thrift/baseplate.thrift
+++ b/baseplate/thrift/baseplate.thrift
@@ -18,3 +18,51 @@ service BaseplateService {
     */
     bool is_healthy(),
 }
+
+
+/** The components of the Reddit LoID cookie that we want to propogate between
+services.
+
+This model is a component of the "Edge-Request" header.  You should not need to
+interact with this model directly, but rather through the EdgeRequestContext
+interface provided by baseplate.
+
+*/
+struct Loid {
+    /** The ID of the LoID cookie.
+
+    */
+    1: string id;
+    /** The time when the LoID cookie was created in epoch milliseconds.
+
+    */
+    2: i64 created_ms;
+}
+
+/** The components of the Reddit Session tracker cookie that we want to
+propogate between services.
+
+This model is a component of the "Edge-Request" header.  You should not need to
+interact with this model directly, but rather through the EdgeRequestContext
+interface provided by baseplate.
+
+*/
+struct Session {
+    /** The ID of the Session tracker cookie.
+
+    */
+    1: string id;
+}
+
+/** Container model for the Edge-Request context header.
+
+Baseplate will automatically parse this from the "Edge-Request" header and
+provides an interface that wraps this Thrift model.  You should not need to
+interact with this model directly, but rather through the EdgeRequestContext
+interface provided by baseplate.
+
+*/
+struct Request {
+    1: Loid loid;
+    2: Session session;
+}

--- a/docs/baseplate/core.rst
+++ b/docs/baseplate/core.rst
@@ -58,40 +58,6 @@ integrations <integration/index>`.
 .. autoclass:: TraceInfo
    :members: from_upstream
 
-Authentication
---------------
-
-If the application is directly receiving authentication from the authentication
-service or if it is receiving and wants to check authentication received from an
-upstream service, there are some support interfaces available for easily working
-with passing context down or picking up passed down contexts.  These helpers allow
-for the application to easily verify and access important values to ensure actions
-it is performing should be allowed in the current context.
-
-When receiving an initial authentication token from the authentication service, the
-application should properly store the token in an
-:py:class:`~baseplate.core.AuthenticationContext` object attached to the current
-context::
-
-    authentication_token = retrieve_token_from_authentication_service()
-    authentication_context = AuthenticationContext(authentication_token, secrets_store)
-    authentication_context.attach_context(context)
-
-This will allow for this token to both be verified correctly and for the token to be
-passed downstream to other services that may need it.
-
-.. autoclass:: AuthenticationContextFactory
-   :members:
-
-.. autoclass:: AuthenticationContext
-   :members:
-
-.. autoclass:: UndefinedSecretsException
-   :members:
-
-.. autoclass:: WithheldAuthenticationError
-   :members:
-
 Spans
 -----
 
@@ -166,6 +132,57 @@ statsd :py:meth:`~!baseplate.core.SpanObserver.on_finish`.
 
 
 .. _convenience_methods:
+
+Edge Request Context
+--------------------
+
+The :py:class:`~baseplate.core.EdgeRequestContext` provides an interface into both
+authentication and context information about the original request from a user.  For edge
+services, it provides helpers to create the initial object and serialize the context
+information into the appropriate headers.  Once this object is created and attached to
+the context, Baseplate will automatically forward the headers to downstream services so they
+can access the authentication and context data as well.
+
+If the application is an edge service that is directly serving client
+requests, then the application should procure an authentication token from the authentication
+service, store the token in an :py:class:`~baseplate.core.AuthenticationContext` object,
+and then store it along with the other context data in an
+:py:class:`~baseplate.core.EdgeRequestContext` object attached to the current context::
+
+    authentication_token = retrieve_token_from_authentication_service()
+    authentication_context = AuthenticationContext(authentication_token, secrets_store)
+    request_context = EdgeRequestContext.create(
+        authentication_context=authentication_context,
+        **edge_request_data
+    )
+    request_context.attach_context(context)
+
+This will allow for the authentication token be verified correctly and for both the
+authentication token and the edge request data to be passed to other services that
+may need it.
+
+.. autoclass:: EdgeRequestContext
+   :members:
+
+.. autoclass:: User
+   :members:
+
+.. autoclass:: OAuthClient
+   :members:
+
+.. autoclass:: Session
+
+.. autoclass:: AuthenticationContextFactory
+   :members:
+
+.. autoclass:: AuthenticationContext
+   :members:
+
+.. autoclass:: UndefinedSecretsException
+   :members:
+
+.. autoclass:: WithheldAuthenticationError
+   :members:
 
 Convenience Methods
 -------------------

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -7,6 +7,7 @@ deserialization
 Deserialize
 deserialized
 Einhorn
+fullname
 gevent
 hostname
 INI
@@ -18,8 +19,10 @@ localhost
 memcache
 Memcache
 memcached
+OAuth
 Queing
 Redis
+Reddit
 schemaless
 schemas
 serializable

--- a/tests/integration/pyramid_tests.py
+++ b/tests/integration/pyramid_tests.py
@@ -49,6 +49,7 @@ def local_tracing_within_context(request):
 class ConfiguratorTests(unittest.TestCase):
     VALID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0X3VzZXJfaWQiLCJleHAiOjQ2NTY1OTM0NTV9.Q8bz2qccFOHLTQ6H3MPdjSh7wDkRQtbBuBwGMzNRKjDFSkCoVF5kiwhBUdwbW8UXO5iZn4Bh7oKdj69lIEOATUxFBblU8Do05EfjECXLYGdbr6ClNmldrB8SsdAtQYQ4Ud-70Z8_75QvkqX_TY5OA4asGJZwH9MC7oHey47-38I"
     TOKEN_SECRET = "-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQC0Kd3qYtc6zI5tj3iKBux70BhE\nZLLJ7fAKNBUO7h9FCwUcYku+SFigzNOu3AAYt3seNgxl+cvMR2+SNwsa605J9D1v\n9eGmpcITQi85SeJnfR7LJUMu7RieY5wEl0RyuwnSkX3Gkv0+hZISC/XYcWEYolIi\n8725u7u/8HRtUeHoLwIDAQAB\n-----END PUBLIC KEY-----"
+    SERIALIZED_REQUEST_HEADER = b"\x0c\x00\x01\x0b\x00\x01\x00\x00\x00\x0bt2_deadbeef\n\x00\x02\x00\x00\x00\x00\x00\x01\x86\xa0\x00\x0c\x00\x02\x0b\x00\x01\x00\x00\x00\x08beefdead\x00\x00"  # noqa
 
     def setUp(self):
         configurator = Configurator()
@@ -126,7 +127,7 @@ class ConfiguratorTests(unittest.TestCase):
         self.assertEqual(server_span.id, 3456)
         self.assertEqual(server_span.sampled, True)
         self.assertEqual(server_span.flags, 1)
-        self.assertFalse(context.authentication.defined)
+        self.assertFalse(context.request_context._authentication_context.defined)
 
         self.assertTrue(self.server_observer.on_start.called)
         self.assertTrue(self.server_observer.on_finish.called)
@@ -142,8 +143,34 @@ class ConfiguratorTests(unittest.TestCase):
         })
         context, _ = self.observer.on_server_span_created.call_args[0]
         try:
-            self.assertTrue(context.authentication.valid)
-            self.assertEqual(context.authentication.account_id, "test_user_id")
+            self.assertEqual(context.request_context.user.id, "test_user_id")
+            self.assertEqual(context.request_context.user.roles, set())
+            self.assertEqual(context.request_context.user.is_logged_in, True)
+            self.assertEqual(context.request_context.oauth_client.id, None)
+            self.assertFalse(context.request_context.oauth_client.is_type("third_party"))
+        except jwt.exceptions.InvalidAlgorithmError:
+            raise unittest.SkipTest("cryptography is not installed")
+
+    def test_edge_request_headers(self):
+        self.test_app.get("/example", headers={
+            "X-Trace": "1234",
+            "X-Authentication": self.VALID_TOKEN,
+            "X-Edge-Request": self.SERIALIZED_REQUEST_HEADER,
+            "X-Parent": "2345",
+            "X-Span": "3456",
+            "X-Sampled": "1",
+            "X-Flags": "1",
+        })
+        context, _ = self.observer.on_server_span_created.call_args[0]
+        try:
+            self.assertEqual(context.request_context.user.id, "test_user_id")
+            self.assertEqual(context.request_context.user.roles, set())
+            self.assertEqual(context.request_context.user.is_logged_in, True)
+            self.assertEqual(context.request_context.user.loid, "t2_deadbeef")
+            self.assertEqual(context.request_context.user.cookie_created_ms, 100000)
+            self.assertEqual(context.request_context.oauth_client.id, None)
+            self.assertFalse(context.request_context.oauth_client.is_type("third_party"))
+            self.assertEqual(context.request_context.session.id, "beefdead")
         except jwt.exceptions.InvalidAlgorithmError:
             raise unittest.SkipTest("cryptography is not installed")
 
@@ -151,13 +178,22 @@ class ConfiguratorTests(unittest.TestCase):
         self.test_app.get("/example", headers={
             "X-Trace": "1234",
             "X-Authentication": "invalid_but_doesnt_matter",
+            "X-Edge-Request": "also_invalid_but_doesnt_matter",
             "X-Parent": "2345",
             "X-Span": "3456",
             "X-Sampled": "1",
             "X-Flags": "1",
         })
         context, _ = self.observer.on_server_span_created.call_args[0]
-        self.assertEqual(context.authentication._token, "invalid_but_doesnt_matter")
+        edge_context_headers = context.request_context.header_values()
+        self.assertEqual(
+            edge_context_headers["Authentication"],
+            "invalid_but_doesnt_matter",
+        )
+        self.assertEqual(
+            edge_context_headers["Edge-Request"],
+            "also_invalid_but_doesnt_matter",
+        )
 
     def test_not_found(self):
         self.test_app.get("/nope", status=404)

--- a/tests/unit/experiments/providers/feature_flag_tests.py
+++ b/tests/unit/experiments/providers/feature_flag_tests.py
@@ -89,7 +89,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "admin": "active",
                     },
                 },
@@ -106,7 +106,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
 
     def test_admin_disabled(self):
@@ -119,7 +119,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "admin": "active",
                     },
                 },
@@ -136,12 +136,12 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=[],
+            user_roles=[],
         ), "active")
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["beta"],
+            user_roles=["beta"],
         ), "active")
 
     def test_employee_enabled(self):
@@ -154,7 +154,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "employee": "active",
                     },
                 },
@@ -171,7 +171,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["employee"],
+            user_roles=["employee"],
         ), "active")
 
     def test_employee_disabled(self):
@@ -184,7 +184,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "employee": "active",
                     },
                 },
@@ -201,12 +201,12 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=[],
+            user_roles=[],
         ), "active")
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["beta"],
+            user_roles=["beta"],
         ), "active")
 
     def test_beta_enabled(self):
@@ -219,7 +219,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "beta": "active",
                     },
                 },
@@ -236,7 +236,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["beta"],
+            user_roles=["beta"],
         ), "active")
 
     def test_beta_disabled(self):
@@ -249,7 +249,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "beta": "active",
                     },
                 },
@@ -266,12 +266,12 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=[],
+            user_roles=[],
         ), "active")
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
 
     def test_gold_enabled(self):
@@ -284,7 +284,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "gold": "active",
                     },
                 },
@@ -301,7 +301,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["gold"],
+            user_roles=["gold"],
         ), "active")
 
     def test_gold_disabled(self):
@@ -314,7 +314,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "gold": "active",
                     },
                 },
@@ -331,12 +331,12 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=[],
+            user_roles=[],
         ), "active")
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
 
     def test_percent_loggedin(self):
@@ -743,7 +743,7 @@ class TestFeatureFlag(unittest.TestCase):
             "global_override": None,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "admin": "active",
                     },
                 },
@@ -756,7 +756,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertNotEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
 
         # globally on but not admin should still be True
@@ -770,7 +770,7 @@ class TestFeatureFlag(unittest.TestCase):
             "global_override": "active",
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "admin": "active",
                     },
                 },
@@ -783,7 +783,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
@@ -800,7 +800,7 @@ class TestFeatureFlag(unittest.TestCase):
             "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
-                    "user_groups": {
+                    "user_roles": {
                         "admin": "active",
                     },
                     "url_features": {
@@ -816,7 +816,7 @@ class TestFeatureFlag(unittest.TestCase):
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,
             logged_in=self.user_logged_in,
-            user_groups=["admin"],
+            user_roles=["admin"],
         ), "active")
         self.assertEqual(feature_flag.variant(
             user_id=self.user_id,

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -448,6 +448,12 @@ class TestSimulatedR2Experiments(unittest.TestCase):
         self.factory = ExperimentsContextFactory("path", self.event_queue)
         self.factory._filewatcher = self.mock_filewatcher
 
+    def get_experiment_client(self, name):
+        span = mock.MagicMock(spec=ServerSpan)
+        span.context = None
+        span.trace_id = "123456"
+        return self.factory.make_object_for_context(name, span)
+
     def _simulate_experiment(self, config, static_vars, target_var, targets):
         num_experiments = len(targets)
         counter = collections.Counter()
@@ -457,9 +463,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             experiment_vars.update(static_vars)
             user = experiment_vars.pop("user")
             content = experiment_vars.pop("content")
-            span = mock.MagicMock(spec=ServerSpan)
-            span.trace_id = "123456"
-            experiments = self.factory.make_object_for_context("test", span)
+            experiments = self.get_experiment_client("test")
             variant = experiments.variant(
                 config["name"],
                 user_id=user["id"],
@@ -518,9 +522,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
         content = content or dict(id=None, type=None)
         self.mock_filewatcher.get_data.return_value = {config["name"]: config}
         for user in users:
-            span = mock.MagicMock(spec=ServerSpan)
-            span.trace_id = "123456"
-            experiments = self.factory.make_object_for_context("test", span)
+            experiments = self.get_experiment_client("test")
             self.assertIs(
                 experiments.variant(
                     config["name"],
@@ -535,9 +537,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
     def assert_no_page_experiment(self, user, pages, config):
         self.mock_filewatcher.get_data.return_value = {config["name"]: config}
         for page in pages:
-            span = mock.MagicMock(spec=ServerSpan)
-            span.trace_id = "123456"
-            experiments = self.factory.make_object_for_context("test", span)
+            experiments = self.get_experiment_client("test")
             self.assertIs(
                 experiments.variant(
                     config["name"],
@@ -554,9 +554,7 @@ class TestSimulatedR2Experiments(unittest.TestCase):
         self.mock_filewatcher.get_data.return_value = {config["name"]: config}
         content = content or dict(id=None, type=None)
         for user in users:
-            span = mock.MagicMock(spec=ServerSpan)
-            span.trace_id = "123456"
-            experiments = self.factory.make_object_for_context("test", span)
+            experiments = self.get_experiment_client("test")
             self.assertEqual(
                 experiments.variant(
                     config["name"],


### PR DESCRIPTION
Provide a framework for passing context data about requests made to edge services between baseplate services.

1. Create Thrift structs to model the request context data.
2. Automatically initialize the `EdgeRequestContext` object from Thrift/HTTP headers.
3. Automatically attach the `Edge-Request` header to thrift requests when using the `PooledClientProxy` client object.
4. Integrate the new `User` and `EdgeRequestContext` objects into the Experiment framework.

NOTE:
This update depends on new fields being added to the AuthenticationContext token.  Currently I have stub functions for these new fields.