### PR TITLE
Add some new experiment fields

### DIFF
--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -174,6 +174,10 @@ class Experiments(object):
         event.set_field("experiment_name", experiment.name)
         event.set_field("owner", experiment.owner)
 
+        version = getattr(experiment, "version", None)
+        if version:
+            event.set_field("version", version)
+
         span_name = "{}.{}".format(self._context_name, "events")
         with self._span.make_child(span_name) as child_span:
             try:

--- a/baseplate/experiments/providers/__init__.py
+++ b/baseplate/experiments/providers/__init__.py
@@ -14,7 +14,7 @@ from .r2 import R2Experiment
 logger = logging.getLogger(__name__)
 
 
-ISO_DATE_FMT = "%Y-%d-%m"
+ISO_DATE_FMT = "%Y-%m-%d"
 
 
 def parse_experiment(config):

--- a/baseplate/experiments/providers/feature_flag.py
+++ b/baseplate/experiments/providers/feature_flag.py
@@ -48,13 +48,14 @@ class FeatureFlag(R2Experiment):
     """
 
     @classmethod
-    def from_dict(cls, id, name, owner, config):
+    def from_dict(cls, id, name, owner, version, config):
         variants = config.get("variants", {})
         assert not set(variants.keys()) - {"active"}
         return super(FeatureFlag, cls).from_dict(
             id=id,
             name=name,
             owner=owner,
+            version=version,
             config=config,
         )
 

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -57,7 +57,7 @@ class R2Experiment(Experiment):
 
     def __init__(self, id, name, owner, variants, seed=None,
                  bucket_val="user_id", targeting=None, overrides=None,
-                 newer_than=None):
+                 newer_than=None, version=None):
         targeting = dict(targeting or {})
         overrides = dict(overrides or {})
         self.targeting = {}
@@ -105,9 +105,10 @@ class R2Experiment(Experiment):
         self.variants = variants
         self.bucket_val = bucket_val
         self.newer_than = newer_than
+        self.version = version
 
     @classmethod
-    def from_dict(cls, id, name, owner, config):
+    def from_dict(cls, id, name, owner, version, config):
         """Parse the config dict and return a new R2Experiment object.
 
         :param int id: The id of the experiment from the base config.
@@ -120,6 +121,7 @@ class R2Experiment(Experiment):
             id=id,
             name=name,
             owner=owner,
+            version=version,
             variants=config["variants"],
             targeting=config.get("targeting"),
             overrides=config.get("overrides"),

--- a/tests/unit/experiments/experiment_tests.py
+++ b/tests/unit/experiments/experiment_tests.py
@@ -3,9 +3,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import time
 import unittest
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from baseplate.core import ServerSpan
 from baseplate.events import EventQueue
@@ -14,12 +15,11 @@ from baseplate.experiments import (
     ExperimentsContextFactory,
     experiments_client_from_config,
 )
-from baseplate.experiments.providers import ISO_DATE_FMT
 from baseplate.file_watcher import FileWatcher, WatchedFileNotAvailableError
 
 from ... import mock
 
-THIRTY_DAYS = timedelta(days=30)
+THIRTY_DAYS = timedelta(days=30).total_seconds()
 
 
 class TestExperiments(unittest.TestCase):
@@ -40,7 +40,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "id": 1,
                     "name": "test",
@@ -76,7 +78,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "variants": {
                         "active": 10,
@@ -112,7 +116,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "variants": {
                         "active": 10,
@@ -151,7 +157,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "variants": {
                         "active": 10,
@@ -185,7 +193,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "variants": {
                         "active": 10,
@@ -253,7 +263,9 @@ class TestExperiments(unittest.TestCase):
                 "name": "test",
                 "owner": "test",
                 "type": "r2",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "variants": {
                         "active": 10,

--- a/tests/unit/experiments/providers/feature_flag_tests.py
+++ b/tests/unit/experiments/providers/feature_flag_tests.py
@@ -8,7 +8,7 @@ import collections
 import time
 import unittest
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from baseplate._compat import range
 from baseplate.core import ServerSpan
@@ -22,7 +22,7 @@ from .... import mock
 logger = logging.getLogger(__name__)
 
 
-THIRTY_DAYS = timedelta(days=30)
+THIRTY_DAYS = timedelta(days=30).total_seconds()
 
 
 class TestFeatureFlag(unittest.TestCase):
@@ -49,7 +49,9 @@ class TestFeatureFlag(unittest.TestCase):
                 "id": 1,
                 "name": "test",
                 "type": "feature_flag",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "targeting": {
                         "logged_in": [True, False],
@@ -82,7 +84,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -110,7 +114,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -143,7 +149,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -171,7 +179,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -204,7 +214,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -232,7 +244,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -265,7 +279,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -293,7 +309,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -329,7 +347,9 @@ class TestFeatureFlag(unittest.TestCase):
                 "id": 1,
                 "name": "test_feature",
                 "type": "feature_flag",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "targeting": {
                         "logged_in": [True],
@@ -362,7 +382,9 @@ class TestFeatureFlag(unittest.TestCase):
                 "id": 1,
                 "name": "test_feature",
                 "type": "feature_flag",
-                "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
                 "experiment": {
                     "targeting": {
                         "logged_in": [False],
@@ -392,7 +414,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "url_features": {
@@ -421,7 +445,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "url_features": {
@@ -449,7 +475,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_name": {
@@ -492,7 +520,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_name": {},
@@ -512,7 +542,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_name": {
@@ -537,7 +569,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subreddit": {
@@ -567,7 +601,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subreddit": {},
@@ -587,7 +623,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subreddit": {
@@ -612,7 +650,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subdomain": {
@@ -642,7 +682,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subdomain": {},
@@ -667,7 +709,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "subdomain": {
@@ -693,7 +737,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "global_override": None,
             "experiment": {
                 "overrides": {
@@ -718,7 +764,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "global_override": "active",
             "experiment": {
                 "overrides": {
@@ -747,7 +795,9 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_groups": {
@@ -783,12 +833,14 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True],
                 },
-                "newer_than": int(time.time()) - THIRTY_DAYS.total_seconds(),
+                "newer_than": int(time.time()) - THIRTY_DAYS,
                 "variants": {
                     "active": 100,
                 },
@@ -810,12 +862,14 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True],
                 },
-                "newer_than": int(time.time()) + THIRTY_DAYS.total_seconds(),
+                "newer_than": int(time.time()) + THIRTY_DAYS,
                 "variants": {
                     "active": 100,
                 },
@@ -838,13 +892,15 @@ class TestFeatureFlag(unittest.TestCase):
             "id": 1,
             "name": "test_feature",
             "type": "feature_flag",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True],
                     "user_name": ["gary"],
                 },
-                "newer_than": int(time.time()) + THIRTY_DAYS.total_seconds(),
+                "newer_than": int(time.time()) + THIRTY_DAYS,
                 "variants": {
                     "active": 100,
                 },

--- a/tests/unit/experiments/providers/forced_variant_tests.py
+++ b/tests/unit/experiments/providers/forced_variant_tests.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import time
 import unittest
 
 from datetime import datetime, timedelta
@@ -10,7 +11,7 @@ from datetime import datetime, timedelta
 from baseplate.experiments.providers import ISO_DATE_FMT, parse_experiment
 from baseplate.experiments.providers.forced_variant import ForcedVariantExperiment
 
-THIRTY_DAYS = timedelta(days=30)
+THIRTY_DAYS = timedelta(days=30).total_seconds()
 
 
 class TestForcedVariantExperiment(unittest.TestCase):
@@ -21,7 +22,9 @@ class TestForcedVariantExperiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "unknown",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "id": 1,
                 "name": "test",
@@ -42,7 +45,9 @@ class TestForcedVariantExperiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "global_override": "foo",
             "experiment": {
                 "id": 1,
@@ -62,7 +67,9 @@ class TestForcedVariantExperiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": False,
             "experiment": {
                 "id": 1,
@@ -75,6 +82,119 @@ class TestForcedVariantExperiment(unittest.TestCase):
         }
         experiment = parse_experiment(cfg)
         self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_before_start_ts_returns_forced_variant(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() + THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS * 2,
+            "enabled": True,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_after_stop_ts_returns_forced_variant(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS * 2,
+            "stop_ts": time.time() - THIRTY_DAYS,
+            "enabled": True,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_after_expires_returns_forced_variant(self):
+        expires = (datetime.now() - timedelta(days=30)).strftime(ISO_DATE_FMT)
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "expires": expires,
+            "enabled": True,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_expires_ignores_start_ts(self):
+        expires = (datetime.now() + timedelta(days=30)).strftime(ISO_DATE_FMT)
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() + THIRTY_DAYS,
+            "expires": expires,
+            "enabled": True,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertFalse(isinstance(experiment, ForcedVariantExperiment))
+
+    def test_start_ts_and_stop_ts_ignore_expires(self):
+        expires = (datetime.now() - timedelta(days=30)).strftime(ISO_DATE_FMT)
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "expires": expires,
+            "enabled": True,
+            "experiment": {
+                "id": 1,
+                "name": "test",
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertFalse(isinstance(experiment, ForcedVariantExperiment))
 
     def test_forced_variant(self):
         experiment = ForcedVariantExperiment("foo")

--- a/tests/unit/experiments/providers/r2_tests.py
+++ b/tests/unit/experiments/providers/r2_tests.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import collections
 import math
 import os
+import time
 import unittest
 
 from datetime import datetime, timedelta
@@ -21,7 +22,7 @@ from baseplate.file_watcher import FileWatcher
 from .... import mock
 
 
-THIRTY_DAYS = timedelta(days=30)
+THIRTY_DAYS = timedelta(days=30).total_seconds()
 
 
 def get_users(num_users, logged_in=True):
@@ -65,7 +66,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "control_1": 10,
@@ -76,6 +79,27 @@ class TestR2Experiment(unittest.TestCase):
         experiment = parse_experiment(cfg)
         self.assertTrue(isinstance(experiment, R2Experiment))
         self.assertTrue(experiment.should_log_bucketing())
+        self.assertEqual(experiment.version, "1")
+
+    def test_no_version_allowed(self):
+        cfg = {
+            "id": 1,
+            "name": "test",
+            "owner": "test",
+            "type": "r2",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
+            "experiment": {
+                "variants": {
+                    "control_1": 10,
+                    "control_2": 10,
+                }
+            }
+        }
+        experiment = parse_experiment(cfg)
+        self.assertTrue(isinstance(experiment, R2Experiment))
+        self.assertTrue(experiment.should_log_bucketing())
+        self.assertIs(experiment.version, None)
 
     def test_calculate_bucket_value(self):
         cfg = {
@@ -83,7 +107,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "control_1": 10,
@@ -99,7 +125,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "seed": "test-seed",
                 "variants": {
@@ -125,7 +153,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "control_1": 10,
@@ -167,7 +197,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "control_1": 10,
@@ -222,7 +254,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "control_only",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "control_1": 10,
@@ -235,7 +269,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "three_variants",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     'remove_vote_counters': 5,
@@ -249,7 +285,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "three_variants_more",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     'remove_vote_counters': 15.6,
@@ -300,7 +338,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "fifty_fifty",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     'control_1': 50,
@@ -313,7 +353,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "almost_fifty_fifty",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     'control_1': 49,
@@ -348,7 +390,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "user_name": {
@@ -373,7 +417,9 @@ class TestR2Experiment(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "overrides": {
                     "logged_in": {
@@ -529,7 +575,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True],
@@ -577,7 +625,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "variants": {
                     "larger": 5,
@@ -602,7 +652,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True],
@@ -630,7 +682,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": True,
             "experiment": {
                 "targeting": {
@@ -659,7 +713,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": False,
             "experiment": {
                 "targeting": {
@@ -688,7 +744,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [False],
@@ -716,7 +774,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [False],
@@ -747,7 +807,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": True,
             "experiment": {
                 "targeting": {
@@ -776,7 +838,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": False,
             "experiment": {
                 "targeting": {
@@ -805,7 +869,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {
                     "logged_in": [True, False],
@@ -829,7 +895,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "enabled": False,
             "experiment": {
                 "targeting": {
@@ -854,7 +922,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "targeting": {},
                 "variants": {
@@ -876,7 +946,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "bucket_val": "content_id",
                 "targeting": {
@@ -916,7 +988,9 @@ class TestSimulatedR2Experiments(unittest.TestCase):
             "name": "test",
             "owner": "test",
             "type": "r2",
-            "expires": (datetime.utcnow() + THIRTY_DAYS).strftime(ISO_DATE_FMT),
+            "version": "1",
+            "start_ts": time.time() - THIRTY_DAYS,
+            "stop_ts": time.time() + THIRTY_DAYS,
             "experiment": {
                 "bucket_val": "content_id",
                 "targeting": {


### PR DESCRIPTION
Add some new fields:

1. version - a string to be passed along with bucketing events
2. start_ts - epoch timestamp float of the time to start the experiment
3. stop_ts - epoch timestamp float of the time to stop the experiment

Deprecate some existing fields:

1. expired - replaced with start_ts and stop_ts.