### PR TITLE
Allow loid_id=None in EdgeRequestContext

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -525,14 +525,16 @@ class EdgeRequestContext(object):
         from .thrift.ttypes import Loid as TLoid
         from .thrift.ttypes import Request as TRequest
         from .thrift.ttypes import Session as TSession
-        session = TSession(id=session_id)
-        if not loid_id.startswith("t2_"):
+
+        if loid_id is not None and not loid_id.startswith("t2_"):
             raise ValueError(
                 "loid_id <%s> is not in a valid format, it should be in the "
                 "fullname format with the '0' padding removed: 't2_loid_id'",
                 loid_id
             )
+
         loid = TLoid(id=loid_id, created_ms=loid_created_ms)
+        session = TSession(id=session_id)
         request = TRequest(loid=loid, session=session)
         header = Serializer.serialize(cls._HEADER_PROTOCOL_FACTORY, request)
         if authentication_context is None:

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -350,6 +350,16 @@ class EdgeRequestContextTests(AuthenticationContextTests):
                 session_id=self.SESSION_ID,
             )
 
+    def test_create_empty_context(self):
+        request_context = EdgeRequestContext.create()
+        self.assertEqual(
+            request_context.header_values(),
+            {
+                "Edge-Request": b'\x0c\x00\x01\x00\x0c\x00\x02\x00\x00',
+                "Authentication": None,
+            },
+        )
+
     def test_logged_out_user(self):
         authentication = AuthenticationContext()
         request_context = EdgeRequestContext(self.SERIALIZED_HEADER, authentication)


### PR DESCRIPTION
When I added some basic validation to the `loid_id` field in `EdgeRequestContext.create` I accidentally made it so you could not set `loid_id=None`.  This fixes that and adds a test for that base case.