### PR TITLE
Change baseplate tween position

### DIFF
--- a/docs/words.txt
+++ b/docs/words.txt
@@ -33,6 +33,7 @@ statsd
 subreddit
 subreddits
 sysctls
+unhandled
 unsampled
 versioned
 Zipkin


### PR DESCRIPTION
Currently, the behavior of the baseplate/pyramid integration
is to handle all exceptions raised. This includes those used as
control flow and intended to be caught by an pyramid exception
view.

This is due to the ordering of the tweens. Here's the current
ordering of tweens, with pyramid's nomenclature in parens:

1. Request ingress (`tweens.INGRESS`)
2. Exception view (`tweens.EXCVIEW`)
3. baseplate tween
4. App handler code (`tweens.MAIN`)

Each tween wraps the one beneath it. Since baseplate is wrapping
the handler code, exceptions get caught by it, reraised, and
then caught by the exception view tween.

This is problematic because it has the effect of calling
`finish` on the server span too early, which triggers all the
observers' `on_finish` callbacks. When we have exceptions or
metrics in the exception view code, they're no longer implicitly
handled by baseplate.

To fix this, we just move the tween up above the exception view.
With this change, all code written by us is covered by the
baseplate tween's try/catch. If an exception view handles a
control flow exception, it doesn't make it up to the baseplate
layer unnecessarily. The final order ends up being:

1. Request ingress (`tweens.INGRESS`)
2. baseplate tween
3. Exception view (`tweens.EXCVIEW`)
4. App handler code (`tweens.MAIN`)