### PR TITLE
Add support for Vault kubernetes auth backend

### DIFF
--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -128,7 +128,7 @@ class VaultClientFactory(object):
 
     def _make_client(self):
         """Obtain a client token from an auth backend and return a Vault client with it."""
-        client_token, lease_duration = self.auth_type()
+        client_token, lease_duration = self.auth_type(self)
 
         return VaultClient(
             self.session,
@@ -173,7 +173,7 @@ class VaultClientFactory(object):
 
         logger.debug("Obtaining Vault token via kubernetes auth.")
         response = self.session.post(
-            urljoin(self.base_url, "v1/%s/login" % self.mount_point),
+            urljoin(self.base_url, "v1/auth/%s/login" % self.mount_point),
             json=login_data,
         )
         response.raise_for_status()

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -6,6 +6,8 @@ The file should contain a section looking like:
     [secret-fetcher]
     vault.url = https://vault.example.com:8200/
     vault.role = my-server-role
+    vault.auth_type = {aws_ec2,kubernetes}
+    vault.auth_path = /v1/auth/{aws-ec2,kubernetes}/login
 
     output.path = /var/local/secrets.json
     output.owner = www-data
@@ -18,7 +20,7 @@ The file should contain a section looking like:
         secret/three,
 
 where each secret is a path to look up in Vault. The daemon authenticates with
-Vault as the EC2 server it is running on. Vault can map that context to
+Vault using the auth backend designated by `auth_type`. Vault can map that context to
 appropriate policies accordingly.
 
 The secrets will be read from Vault and written to output.path as a JSON file

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -112,12 +112,12 @@ def ttl_to_time(ttl):
 class VaultClientFactory(object):
     """Factory that makes authenticated clients."""
     def __init__(self, base_url, role, auth_type, auth_path):
-        self.base_url  = base_url
-        self.role      = role
+        self.base_url = base_url
+        self.role = role
         self.auth_type = auth_type
         self.auth_path = auth_path
-        self.session   = requests.Session()
-        self.client    = None
+        self.session = requests.Session()
+        self.client = None
 
     def _make_client(self):
         """Obtain a client token from an auth backend and return a Vault client with it."""
@@ -155,9 +155,9 @@ class VaultClientFactory(object):
 
         """
         try:
-            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE , "r") as f:
+            with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE, "r") as f:
                 token = f.read()
-        except IOError as exc:
+        except IOError:
             logger.debug("Could not read Kubernetes token file '%s'",
                          K8S_SERVICE_ACCOUNT_TOKEN_FILE)
             raise

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -138,7 +138,7 @@ class VaultClientFactory(object):
         )
 
     def _vault_kubernetes_auth(self):
-        """Gets a client token from Vault through the Kubernetes auth backend.
+        """Get a client token from Vault through the Kubernetes auth backend.
 
         This authenticates with Vault as a specified role using its
         Kubernetes auth backend. This involves sending Vault a JSON Web Token
@@ -181,7 +181,7 @@ class VaultClientFactory(object):
         return auth["client_token"], ttl_to_time(auth["lease_duration"])
 
     def _vault_aws_auth(self):
-        """Gets a client token from Vault through the AWS auth backend.
+        """Get a client token from Vault through the AWS auth backend.
 
         This authenticates with Vault as a specified role using its AWS
         auth backend. This involves sending to Vault the AWS-signed instance
@@ -226,7 +226,7 @@ class VaultClientFactory(object):
 
     @staticmethod
     def auth_types():
-        """Returns a dict of the supported auth types and respective methods."""
+        """Return a dict of the supported auth types and respective methods."""
         return {
             "aws": VaultClientFactory._vault_aws_auth,
             "kubernetes": VaultClientFactory._vault_kubernetes_auth,

--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -158,7 +158,7 @@ class VaultClientFactory(object):
             with open(K8S_SERVICE_ACCOUNT_TOKEN_FILE, "r") as f:
                 token = f.read()
         except IOError:
-            logger.debug("Could not read Kubernetes token file '%s'",
+            logger.error("Could not read Kubernetes token file '%s'",
                          K8S_SERVICE_ACCOUNT_TOKEN_FILE)
             raise
 

--- a/docs/baseplate/secrets.rst
+++ b/docs/baseplate/secrets.rst
@@ -7,11 +7,13 @@ Fetcher Daemon
 --------------
 
 The secret fetcher is a sidecar that is run as a single daemon on each server.
-It authenticates to Vault as the server itself and gets appropriate policies
-for access to secrets accordingly. Once authenticated, it fetches a given list
-of secrets from Vault and stores all of the data in a local file. It will
-automatically re-fetch secrets as their leases expire, ensuring that key
-rotation happens on schedule.
+It can authenticate to Vault either as the server itself (through an AWS-signed
+instance identity document) or through a mounted JWT when running within a
+Kubernetes pod. It then gets access to secrets based upon the policies mapped
+to the role it authenticated as. Once authenticated, it fetches a given
+list of secrets from Vault and stores all of the data in a local file.
+It will automatically re-fetch secrets as their leases expire, ensuring
+that key rotation happens on schedule.
 
 Because this is a sidecar, individual application processes don't need to talk
 directly to Vault for simple secret tokens (but can do so if needed for more

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -1,4 +1,5 @@
 aggregator
+AWS
 backend
 backends
 backoff
@@ -13,6 +14,7 @@ hostname
 INI
 Interana
 iterable
+Kubernetes
 kwargs
 lifecycle
 localhost


### PR DESCRIPTION
related issue: https://github.com/reddit/baseplate/issues/132

In `VaultClientFactory`, `_make_client` now delegates the logic of fetching the client token to the appropriate auth backend method. To prevent breakage of downstream services, the original aws_ec2 authentication method is kept as default.

Services wishing to utilize the kubernetes auth backend will configure an ini like so:
```
[secret-fetcher]
vault.url = https://vault.url:8200
vault.role = some-service-role
vault.auth_type = kubernetes
vault.auth_path = /v1/auth/kubernetes/login
```