### PR TITLE
Don't retry publishing forever when v2 event fails to validate

### DIFF
--- a/baseplate/events/publisher.py
+++ b/baseplate/events/publisher.py
@@ -195,7 +195,8 @@ class BatchPublisher(object):
                 logger.exception("HTTP Request failed")
 
                 # we should crash if it's our fault
-                if getattr(exc, "response", None) and exc.response.status_code < 500:
+                response = getattr(exc, "response", None)
+                if response is not None and response.status_code < 500:
                     raise
             except IOError:
                 self.metrics.counter("error.io").increment()


### PR DESCRIPTION
The previous check didn't work properly because requests.Response has
`__bool__` defined as "Returns True if `status_code` is less than 400."
which meant that it was always falsey in the situations we wanted to
check it. Instead, we now just explicitly check if it's `None` and crash
on validation failure. This will discard the current message batch and
upstart will restart us to carry on with further messages.

cc @robdmac since this was biting you on staging the other day.