### PR TITLE
Emit an event to Pyramid after creating the ServerSpan

### DIFF
--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -17,6 +17,20 @@ An abbreviated example of it in use::
 
         return configurator.make_wsgi_app()
 
+Events
+------
+
+Baseplate will emit events at various stages of the request lifecycle that
+services can hook into.
+
+:py:class:`ServerSpanInitialized` - Fired after Baseplate initializes the
+ServerSpan for a new Request and before passing the Request to it's handler.
+Note, that Baseplate initializes the ServerSpan in response to a
+:py:class:`pyramid.events.ContextFound` event emitted by Pyramid so while we
+can guarantee what Baseplate has done when this event is emitted, we cannot
+guarantee that any other subscribers to :py:class:`pyramid.events.ContextFound`
+have been called or not.
+
 .. warning::
 
     Because of how Baseplate instruments Pyramid, you should not make an

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -62,6 +62,16 @@ def _make_baseplate_tween(handler, registry):
     return baseplate_tween
 
 
+class BaseplateEvent(object):
+
+    def __init__(self, request):
+        self.request = request
+
+
+class BaseplateContextInitialized(BaseplateEvent):
+    pass
+
+
 # pylint: disable=abstract-class-not-used
 class BaseplateConfigurator(object):
     """Config extension to integrate Baseplate into Pyramid.
@@ -136,6 +146,7 @@ class BaseplateConfigurator(object):
         request.trace.set_tag("http.url", request.url)
         request.trace.set_tag("http.method", request.method)
         request.trace.set_tag("peer.ipv4", request.remote_addr)
+        request.registry.notify(BaseplateContextInitialized(request))
 
     def _start_server_span(self, request, name, trace_info=None):
         request.trace = self.baseplate.make_server_span(

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -68,7 +68,9 @@ class BaseplateEvent(object):
         self.request = request
 
 
-class BaseplateContextInitialized(BaseplateEvent):
+class ServerSpanInitialized(BaseplateEvent):
+    """Event that Baselpate fires after creating the ServerSpan for a Request.
+    """
     pass
 
 
@@ -146,7 +148,6 @@ class BaseplateConfigurator(object):
         request.trace.set_tag("http.url", request.url)
         request.trace.set_tag("http.method", request.method)
         request.trace.set_tag("peer.ipv4", request.remote_addr)
-        request.registry.notify(BaseplateContextInitialized(request))
 
     def _start_server_span(self, request, name, trace_info=None):
         request.trace = self.baseplate.make_server_span(
@@ -155,6 +156,7 @@ class BaseplateConfigurator(object):
             trace_info=trace_info,
         )
         request.trace.start()
+        request.registry.notify(ServerSpanInitialized(request))
 
     def includeme(self, config):
         config.add_subscriber(self._on_new_request, pyramid.events.ContextFound)

--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -17,20 +17,6 @@ An abbreviated example of it in use::
 
         return configurator.make_wsgi_app()
 
-Events
-------
-
-Baseplate will emit events at various stages of the request lifecycle that
-services can hook into.
-
-:py:class:`ServerSpanInitialized` - Fired after Baseplate initializes the
-ServerSpan for a new Request and before passing the Request to it's handler.
-Note, that Baseplate initializes the ServerSpan in response to a
-:py:class:`pyramid.events.ContextFound` event emitted by Pyramid so while we
-can guarantee what Baseplate has done when this event is emitted, we cannot
-guarantee that any other subscribers to :py:class:`pyramid.events.ContextFound`
-have been called or not.
-
 .. warning::
 
     Because of how Baseplate instruments Pyramid, you should not make an
@@ -83,7 +69,14 @@ class BaseplateEvent(object):
 
 
 class ServerSpanInitialized(BaseplateEvent):
-    """Event that Baselpate fires after creating the ServerSpan for a Request.
+    """Event that Baseplate fires after creating the ServerSpan for a Request.
+
+    This event will be emitted before the Request is passed along to it's
+    handler.  Baseplate initializes the ServerSpan in response to a
+    :py:class:`pyramid.events.ContextFound` event emitted by Pyramid so while
+    we can guarantee what Baseplate has done when this event is emitted, we
+    cannot guarantee that any other subscribers to
+    :py:class:`pyramid.events.ContextFound` have been called or not.
     """
     pass
 

--- a/docs/baseplate/integration/index.rst
+++ b/docs/baseplate/integration/index.rst
@@ -20,3 +20,11 @@ Pyramid
 .. automodule:: baseplate.integration.pyramid
 
 .. autoclass:: baseplate.integration.pyramid.BaseplateConfigurator
+
+Pyramid Events
+--------------
+
+Baseplate will emit events at various stages of the request lifecycle that
+services can hook into.
+
+.. autoclass:: baseplate.integration.pyramid.ServerSpanInitialized

--- a/docs/baseplate/integration/index.rst
+++ b/docs/baseplate/integration/index.rst
@@ -21,8 +21,8 @@ Pyramid
 
 .. autoclass:: baseplate.integration.pyramid.BaseplateConfigurator
 
-Pyramid Events
---------------
+Events
+~~~~~~
 
 Within its Pyramid integration, Baseplate will emit events at various stages
 of the request lifecycle that services can hook into.

--- a/docs/baseplate/integration/index.rst
+++ b/docs/baseplate/integration/index.rst
@@ -24,7 +24,7 @@ Pyramid
 Pyramid Events
 --------------
 
-Baseplate will emit events at various stages of the request lifecycle that
-services can hook into.
+Within it's Pyramid integraton, Baseplate will emit events at various stages of
+the request lifecycle that services can hook into.
 
 .. autoclass:: baseplate.integration.pyramid.ServerSpanInitialized

--- a/docs/baseplate/integration/index.rst
+++ b/docs/baseplate/integration/index.rst
@@ -24,7 +24,7 @@ Pyramid
 Pyramid Events
 --------------
 
-Within it's Pyramid integraton, Baseplate will emit events at various stages of
-the request lifecycle that services can hook into.
+Within it's Pyramid integration, Baseplate will emit events at various stages
+of the request lifecycle that services can hook into.
 
 .. autoclass:: baseplate.integration.pyramid.ServerSpanInitialized

--- a/docs/baseplate/integration/index.rst
+++ b/docs/baseplate/integration/index.rst
@@ -24,7 +24,7 @@ Pyramid
 Pyramid Events
 --------------
 
-Within it's Pyramid integration, Baseplate will emit events at various stages
+Within its Pyramid integration, Baseplate will emit events at various stages
 of the request lifecycle that services can hook into.
 
 .. autoclass:: baseplate.integration.pyramid.ServerSpanInitialized


### PR DESCRIPTION
Right now, there's not really a step between Baseplate running it's initialization on the Pyramid Request object and the service handling the request which makes it difficult to run code that you want to run before each request but after Baseplate has attached the client objects to the requests (say authenticating the request with a thrift service).

With this change, Baseplate will emit an event after it creates the ServerSpan for the request that services can add subscribers to in order to run code like this.