### PR TITLE
Add thrift build step to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,9 @@
+import os
 import sys
 
+import setuptools.command.build_py
+import subprocess
+from distutils.spawn import find_executable
 from setuptools import setup, find_packages
 
 
@@ -40,6 +44,30 @@ extras_require = {
         "alabaster",
     ],
 }
+
+
+class BuildPyCommand(setuptools.command.build_py.build_py):
+    """Custom build command for packaging."""
+
+    def _make_thrift(self):
+        """Generate Baseplate Thrift definitions.
+        """
+        # Verify build dependencies are installed.
+        if not find_executable('make'):
+            print("'make' not found.")
+            exit(1)
+
+        if not find_executable('thrift1'):
+            print("Thrift compiler not found.")
+            exit(1)
+
+        make_cmd = ['/usr/bin/make', 'thrift']
+        subprocess.check_call(make_cmd)
+
+    def run(self):
+        self._make_thrift()
+        setuptools.command.build_py.build_py.run(self)
+
 
 setup(
     name="baseplate",
@@ -96,4 +124,7 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Software Development :: Libraries :: Application Frameworks",
     ],
+    cmdclass={
+        'build_py': BuildPyCommand,
+    },
 )


### PR DESCRIPTION
In order to support Wheels builds of Baseplate, we need to
make sure that we compile Baseplate thrift definitions before
packaging. 

Building Baseplate strictly via `sdist` or other mechanisms
that rely on setup.py will lead to silent failures upon installation
for the baseplate.thrift module because there is no definition
in the setup.py build step for generating the included Baseplate
Thrift definitions in `baseplate/thrift/baseplate.thrift`. This adds
an override to build_py to generate Thrift files via the Makefile
and checks for a valid Thrift compiler. 

Note: I have very limited experience with properly extending setuptools stuff 
so if there's other patterns to follow here I'm happy to change things. I tested
this locally and got a working wheels build with these changes as well as the 
standard sdist that gets uploaded to PyPi. 

:eyeglasses: @spladug @pacejackson 