### PR TITLE
Use /usr/bin/env python for Baseplate scripts

### DIFF
--- a/bin/baseplate-script
+++ b/bin/baseplate-script
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # this is here and not just a console_script entry point because we want the
 # gevent monkeypatching to happen before any pieces of baseplate are imported

--- a/bin/baseplate-serve
+++ b/bin/baseplate-serve
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # this is here and not just a console_script entry point because we want the
 # gevent monkeypatching to happen before any pieces of baseplate are imported


### PR DESCRIPTION
Using /usr/bin/env python instead of the direct system Python
for Baseplate-included scripts makes Baseplate more friendly
for virtualenv-based and other isolated environment installs.

:eyeglasses: @spladug 