### PR TITLE
Add a histogram interface to Baseplate's metrics support

### DIFF
--- a/docs/baseplate/metrics.rst
+++ b/docs/baseplate/metrics.rst
@@ -29,3 +29,7 @@ Metrics
 .. autoclass:: Gauge()
    :members:
    :undoc-members:
+
+.. autoclass:: Histogram()
+   :members:
+   :undoc-members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ separately from the rest of Baseplate.
    baseplate.file_watcher: Read files from disk as they change <baseplate/file_watcher>
    baseplate.live_data: Tools for centralized data that updates near instantly <baseplate/live_data>
    baseplate.message_queue: POSIX IPC Message Queues <baseplate/message_queue>
-   baseplate.metrics: Counters and timers for statsd <baseplate/metrics>
+   baseplate.metrics: Counters, timers, gauges, and histograms for statsd <baseplate/metrics>
    baseplate.random: Extensions to the standard library's random module <baseplate/random>
    baseplate.retry: Policies for retrying operations <baseplate/retry>
    baseplate.secrets: Secure storage and access to secret tokens and credentials <baseplate/secrets>

--- a/docs/words.txt
+++ b/docs/words.txt
@@ -32,6 +32,7 @@ serialized
 serializer
 Serializers
 statsd
+StatsD
 subreddit
 subreddits
 sysctls


### PR DESCRIPTION
This adds a simple histogram interface to Baseplate metrics.
Our implementation sends simple values as timer stats to the StatsD
backend, expecting the backend to be configured to aggregate
and store histograms, e.g. [Statsite](https://github.com/statsite/statsite/blob/master/README.md#architecture) (Search "histograms"). 

Histograms on top of timers is currently
in both etsy's StatsD implementation as well as Statsite, and anyone trying to use
this with a backend that doesn't have histograms configured will just be sending arbitrary timer values. 

Even though this is just a simple wrapper around timers, I think the 
Histogram abstraction is worth adding. 

:eyeglasses: @spladug 