### PR TITLE
Add failure counter for server spans

### DIFF
--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -40,7 +40,7 @@ class MetricsServerSpanObserver(SpanObserver):
     def __init__(self, batch, server_span):
         self.batch = batch
         self.base_name = "server." + server_span.name
-        self.timer = batch.timer("server." + server_span.name)
+        self.timer = batch.timer(self.base_name)
 
     def on_start(self):
         self.timer.start()

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -39,6 +39,7 @@ class MetricsBaseplateObserver(BaseplateObserver):
 class MetricsServerSpanObserver(SpanObserver):
     def __init__(self, batch, server_span):
         self.batch = batch
+        self.base_name = "server." + server_span.name
         self.timer = batch.timer("server." + server_span.name)
 
     def on_start(self):

--- a/baseplate/diagnostics/metrics.py
+++ b/baseplate/diagnostics/metrics.py
@@ -46,6 +46,8 @@ class MetricsServerSpanObserver(SpanObserver):
 
     def on_finish(self, exc_info):
         self.timer.stop()
+        suffix = "success" if not exc_info else "failure"
+        self.batch.counter(self.base_name + "." + suffix).increment()
         self.batch.flush()
 
     def on_child_span_created(self, span):

--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -91,14 +91,13 @@ class BufferedTransport(object):
         self.buffer.append(serialized_metric)
 
     def flush(self):
-        # TODO: warn when buffer length reaches MTU
-        # TODO: run-length compression
         metrics, self.buffer = self.buffer, []
         message = b"\n".join(metrics)
         try:
             self.transport.send(message)
         except socket.error as e:
-            logger.error("BufferedTransport flush exception, length %d, %s",
+            logger.error("baseplate metrics batch too large: flush more often \
+                or reduce amount done in one request, length %d, %s",
                 len(message), e)
 
 

--- a/baseplate/metrics.py
+++ b/baseplate/metrics.py
@@ -95,7 +95,11 @@ class BufferedTransport(object):
         # TODO: run-length compression
         metrics, self.buffer = self.buffer, []
         message = b"\n".join(metrics)
-        self.transport.send(message)
+        try:
+            self.transport.send(message)
+        except socket.error as e:
+            logger.error("BufferedTransport flush exception, length %d, %s",
+                len(message), e)
 
 
 class BaseClient(object):

--- a/tests/unit/metrics_tests.py
+++ b/tests/unit/metrics_tests.py
@@ -74,6 +74,19 @@ class BufferedTransportTests(unittest.TestCase):
         self.assertEqual(mocket.sendall.call_args,
             mock.call(b"a\nb\nc"))
 
+    @mock.patch("socket.socket")
+    def test_buffered_exception_is_caught(self, mock_make_socket):
+        mocket = mock_make_socket.return_value
+        mocket.sendall.side_effect = mock.Mock(
+            side_effect=socket.error('Test'))
+        raw_transport = metrics.RawTransport(EXAMPLE_ENDPOINT)
+        transport = metrics.BufferedTransport(raw_transport)
+        for i in range(10000):
+            transport.send(b"a")
+
+        self.assertEqual(mocket.sendall.call_count, 0)
+        transport.flush()
+
 
 class BaseClientTests(unittest.TestCase):
     def test_encode_namespace(self):


### PR DESCRIPTION
There has been an ongoing conversation in https://reddit.atlassian.net/browse/IO-2820 asking for error counts. This exists for the clients, this PR should add them for the server spans as well.