### PR TITLE
Add Makefile to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include bin/baseplate-*
 include baseplate/thrift/*.thrift
+include Makefile


### PR DESCRIPTION
This adds the Baseplate Makefile to the source distribution
in order to support building the project from source using
setup.py. setup.py relies on the Makefile for building
Baseplate Thrift definitions.

This specifically supports building a Baseplate Wheel package from the PyPI source distribution (or any other PyPI-like distribution repository). 

:eyeglasses: @spladug 