### PR TITLE
Allow you to run the secret-fetcher as a script rather than a daemon

### DIFF
--- a/baseplate/secrets/fetcher.py
+++ b/baseplate/secrets/fetcher.py
@@ -283,9 +283,11 @@ def main():
     if args.debug:
         level = logging.DEBUG
     else:
-        level = logging.WARNING
-    logging.basicConfig(level=level)
+        level = logging.INFO
 
+    logging.basicConfig(
+        format='%(asctime)s:%(levelname)s:%(message)s',
+        level=level)
     parser = configparser.RawConfigParser()
     parser.readfp(args.config_file)
     fetcher_config = dict(parser.items("secret-fetcher"))


### PR DESCRIPTION
While you generally want to run the secret fetcher as a daemon so it will pick up any updates, there are some situations where you only want to run it once.  This PR adds a `--once` argument to `secret_fetcher.py` that allows you to run it a single time and then exit.