### PR TITLE
Baseplate healthcheck rework

### DIFF
--- a/bin/baseplate-healthcheck
+++ b/bin/baseplate-healthcheck
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+# Perform health-checks for a baseplate service.
+
+from baseplate.server.healthcheck import run_healthchecks
+run_healthchecks()

--- a/debian/rules
+++ b/debian/rules
@@ -5,6 +5,22 @@ export PYBUILD_NAME=baseplate
 %:
 	dh $@ --with python2,python3,sphinxdoc --buildsystem=pybuild
 
+PHONY: override_dh_python2
+override_dh_python2:
+	dh_python2
+	mv ./debian/python-baseplate/usr/bin/baseplate-serve ./debian/python-baseplate/usr/bin/baseplate-serve2
+	mv ./debian/python-baseplate/usr/bin/baseplate-script ./debian/python-baseplate/usr/bin/baseplate-script2
+	mv ./debian/python-baseplate/usr/bin/baseplate-tshell ./debian/python-baseplate/usr/bin/baseplate-tshell2
+	mv ./debian/python-baseplate/usr/bin/baseplate-healthcheck ./debian/python-baseplate/usr/bin/baseplate-healthcheck2
+
+.PHONY: override_dh_python3
+override_dh_python3:
+	dh_python3
+	mv ./debian/python3-baseplate/usr/bin/baseplate-serve ./debian/python3-baseplate/usr/bin/baseplate-serve3
+	mv ./debian/python3-baseplate/usr/bin/baseplate-script ./debian/python3-baseplate/usr/bin/baseplate-script3
+	mv ./debian/python3-baseplate/usr/bin/baseplate-tshell ./debian/python3-baseplate/usr/bin/baseplate-tshell3
+	mv ./debian/python3-baseplate/usr/bin/baseplate-healthcheck ./debian/python3-baseplate/usr/bin/baseplate-healthcheck3
+
 .PHONY: override_dh_auto_build
 override_dh_auto_build:
 	make thrift

--- a/setup.py
+++ b/setup.py
@@ -87,9 +87,10 @@ setup(
     tests_require=tests_require,
 
     scripts=[
-        "bin/baseplate-serve{:d}".format(sys.version_info.major),
-        "bin/baseplate-script{:d}".format(sys.version_info.major),
-        "bin/baseplate-tshell{:d}".format(sys.version_info.major),
+        "bin/baseplate-serve",
+        "bin/baseplate-script",
+        "bin/baseplate-tshell",
+        "bin/baseplate-healthcheck",
     ],
 
     # the thrift compiler must be able to find baseplate.thrift to build
@@ -103,11 +104,6 @@ setup(
     entry_points={
         "distutils.commands": [
             "build_thrift = baseplate.integration.thrift.command:BuildThriftCommand",
-        ],
-
-        "console_scripts": [
-            "baseplate-healthcheck{:d} = baseplate.server.healthcheck:run_healthchecks".format(
-                sys.version_info.major),
         ],
 
         "paste.app_factory": [


### PR DESCRIPTION
Rather than installing version-specific baseplate scripts, this moves to a central `baseplate-<script-name>` format so interfacing with these scripts can be the same across Python version installations. For Debian packages, we still include version-specific scripts to allow Python2-baseplate and Python3-baseplate to be installed on the same system. 

:eyeglasses: @spladug 