### PR TITLE
Ensure that connection failures do not deplete ThriftConnectionPools.

### DIFF
--- a/baseplate/thrift_pool.py
+++ b/baseplate/thrift_pool.py
@@ -166,6 +166,8 @@ class ThriftConnectionPool(object):
 
             return prot
 
+        self.pool.put(None)
+
         raise TTransportException(
             type=TTransportException.NOT_OPEN,
             message="giving up after multiple attempts to connect",

--- a/tests/unit/thrift_pool_tests.py
+++ b/tests/unit/thrift_pool_tests.py
@@ -135,6 +135,9 @@ class ThriftConnectionPoolTests(unittest.TestCase):
         with self.assertRaises(TTransport.TTransportException):
             self.pool._acquire()
 
+        self.assertEqual(self.mock_queue.put.call_count, 1)
+        self.assertEqual(self.mock_queue.put.call_args, mock.call(None))
+
     def test_release_open(self):
         mock_prot = mock.Mock(spec=THeaderProtocol.THeaderProtocol)
         mock_prot.trans = mock.Mock(spec=THeaderTransport.THeaderTransport)


### PR DESCRIPTION
This commit modifies `ThriftConnectionPool._acquire` in order to put a blank (`None`) connection entry back in pool if the retry policy is exhausted while trying to connect to the host.

Previously, one connection pool slot would be lost each time `_acquire` failed to secure a new connection to the host which could eventually drain the connection pool size to zero.