### PR TITLE
Exposure events

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -299,8 +299,8 @@ class User(_User):
 
         return {
             "user_id": user_id,
-            "user_logged_in": self.is_logged_in,
-            "cookie_created": self.cookie_created_ms,
+            "logged_in": self.is_logged_in,
+            "cookie_created_timestamp": self.cookie_created_ms,
         }
 
 

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -190,7 +190,7 @@ class Experiments(object):
         return variant
 
 
-def experiments_client_from_config(app_config, event_queue):
+def experiments_client_from_config(app_config, event_logger):
     """Configure and return an :py:class:`ExperimentsContextFactory` object.
 
     This expects one configuration option:
@@ -201,15 +201,15 @@ def experiments_client_from_config(app_config, event_queue):
 
     :param dict raw_config: The application configuration which should have
         settings for the experiments client.
-    :param baseplate.events.EventQueue event_queue: The EventQueue to be used
+    :param baseplate.events.EventQueue event_logger: The EventLogger to be used
         to log bucketing events.
     :rtype: :py:class:`ExperimentsContextFactory`
 
-    """
+    """ 
     cfg = config.parse_config(app_config, {
         "experiments": {
             "path": config.Optional(config.String, default="/var/local/experiments.json"),
         },
     })
     # pylint: disable=maybe-no-member
-    return ExperimentsContextFactory(cfg.experiments.path, event_queue)
+    return ExperimentsContextFactory(cfg.experiments.path, event_logger)

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -90,6 +90,30 @@ class Experiments(object):
             self._experiment_cache[name] = experiment
         return self._experiment_cache[name]
 
+    def get_all_experiment_names(self):
+        """Returns a list of all valid experiment names from the
+        configuration file.
+
+        :rtype: :py:class:`list`
+        :return: List of all valid experiment names.
+        """
+        config = self._config_watcher.get_data()
+        experiment_names = list(config.keys())
+
+        return experiment_names
+
+    def is_valid_experiment(self, name):
+        """Returns true if the provided experiment name is a valid
+        experiment.
+
+        :param str name: Name of the experiment you want to check.
+
+        :rtype: :py:class:`bool`
+        :return: Whether or not a particular experiment is valid.
+        """
+
+        return self._get_experiment(name) is not None
+
     def variant(self, name, user=None, bucketing_event_override=None,
                 extra_event_fields=None, **kwargs):
         """Which variant, if any, is active.

--- a/baseplate/experiments/providers/r2.py
+++ b/baseplate/experiments/providers/r2.py
@@ -308,7 +308,7 @@ class R2Experiment(Experiment):
             num_variants *
             bucket_multiplier
         )
-        if bucket < bucket_limit:
+        if bucket < int(bucket_limit):
             return candidate_variant
         else:
             return None

--- a/tests/unit/core_tests.py
+++ b/tests/unit/core_tests.py
@@ -336,8 +336,8 @@ class EdgeRequestContextTests(unittest.TestCase):
             request_context.event_fields(),
             {
                 "user_id": self.LOID_ID,
-                "user_logged_in": False,
-                "cookie_created": self.LOID_CREATED_MS,
+                "logged_in": False,
+                "cookie_created_timestamp": self.LOID_CREATED_MS,
                 "session_id": self.SESSION_ID,
                 "oauth_client_id": None,
             },
@@ -360,8 +360,8 @@ class EdgeRequestContextTests(unittest.TestCase):
             request_context.event_fields(),
             {
                 "user_id": "t2_example",
-                "user_logged_in": True,
-                "cookie_created": self.LOID_CREATED_MS,
+                "logged_in": True,
+                "cookie_created_timestamp": self.LOID_CREATED_MS,
                 "session_id": self.SESSION_ID,
                 "oauth_client_id": None,
             },
@@ -388,8 +388,8 @@ class EdgeRequestContextTests(unittest.TestCase):
             request_context.event_fields(),
             {
                 "user_id": self.LOID_ID,
-                "user_logged_in": False,
-                "cookie_created": self.LOID_CREATED_MS,
+                "logged_in": False,
+                "cookie_created_timestamp": self.LOID_CREATED_MS,
                 "session_id": self.SESSION_ID,
                 "oauth_client_id": None,
             },

--- a/tests/unit/experiments/experiment_tests.py
+++ b/tests/unit/experiments/experiment_tests.py
@@ -393,8 +393,8 @@ class TestExperiments(unittest.TestCase):
 
 class ExperimentsClientFromConfigTests(unittest.TestCase):
     def test_make_clients(self):
-        event_queue = mock.Mock(spec=DebugLogger)
+        event_logger = mock.Mock(spec=DebugLogger)
         experiments = experiments_client_from_config({
             "experiments.path": "/tmp/test",
-        }, event_queue)
+        }, event_logger)
         self.assertIsInstance(experiments, ExperimentsContextFactory)


### PR DESCRIPTION
- support for firing exposure events
- support for validating experiment names (to differentiate between when `variant` returns null because not bucketed, or "invalid" experiment name
- support for getting a list of all experiment names. This will be used to bucket a user for all (valid) experiments in order to return the full list of variants in a single call.
- fix weird bucketing issue with very small bucketing percentages on r2 experiments
- replace `event_queue` with `event_logger`