### PR TITLE
Simplify trace publisher config

### DIFF
--- a/tests/unit/diagnostics/tracing/publisher_tests.py
+++ b/tests/unit/diagnostics/tracing/publisher_tests.py
@@ -19,10 +19,15 @@ class ZipkinPublisherTest(unittest.TestCase):
     def setUp(self, mock_Session):
         self.session = mock_Session.return_value
         self.metrics_client = mock.MagicMock(autospec=metrics.Client)
+        self.zipkin_api_url = "http://test.local/api/v2"
         self.publisher = publisher.ZipkinPublisher(
-            'test.local',
+            self.zipkin_api_url,
             self.metrics_client,
         )
+
+    def test_initialization(self):
+        self.assertEqual(self.publisher.endpoint, "{}/spans".format(self.zipkin_api_url))
+        self.publisher.session.mount.assert_called_with("http://", mock.ANY)
 
     def test_empty_batch(self):
         self.publisher.publish(SerializedBatch(count=0, bytes=b""))


### PR DESCRIPTION
While making changes to the baseplate puppet module I realized I made a
few mistakes in the final round of changes in trace sidecar PR. I wanted to set
them straight before the next version of baseplate is officially
released.

These changes include:

* Renaming the config section from "tracing-publisher" to "trace-publisher". This is more in line with the existing Event publisher config section.
* Remove all Zipkin scheme and API version settings. Instead rely on the ``zipkin_api_url`` config option.

👓 @spladug 