### PR TITLE
Fix decode bug

### DIFF
--- a/baseplate/context/memcache/__init__.py
+++ b/baseplate/context/memcache/__init__.py
@@ -253,7 +253,7 @@ def make_keys_str(keys):
     """Make a string representation of an iterable of keys.
 
     """
-    keys_str = ','.join(x.decode("utf-8") for x in keys)
+    keys_str = ",".join(x.decode("utf-8") if isinstance(x, bytes) else x for x in keys)
     if len(keys_str) > 100:
         return keys_str[:100] + "..."
     else:

--- a/tests/integration/memcache_tests.py
+++ b/tests/integration/memcache_tests.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     raise unittest.SkipTest("pymemcache is not installed")
 
-from baseplate.context.memcache import MemcacheContextFactory, MonitoredMemcacheConnection
+from baseplate.context.memcache import (MemcacheContextFactory,
+    MonitoredMemcacheConnection, make_keys_str)
 from baseplate.core import Baseplate, LocalSpan, ServerSpan
 
 from . import TestBaseplateObserver, skip_if_server_unavailable
@@ -57,7 +58,6 @@ class MemcacheIntegrationTests(unittest.TestCase):
         self.assertTrue(span_observer.on_start_called)
         self.assertTrue(span_observer.on_finish_called)
         self.assertIsNotNone(span_observer.on_finish_exc_info)
-
 
 
 class MonitoredMemcacheConnectionIntegrationTests(unittest.TestCase):
@@ -173,3 +173,15 @@ class MonitoredMemcacheConnectionIntegrationTests(unittest.TestCase):
         self.connection.quit()
         self.mocked_pool.quit.assert_called_with()
         self.assertEqual(self.local_span.set_tag.call_count, 1)
+
+
+class MakeKeysStrTests(unittest.TestCase):
+    def test_bytes(self):
+        expected_string = "key_1,key_2"
+        keys = [b"key_1", b"key_2"]
+        self.assertEqual(expected_string, make_keys_str(keys))
+
+    def test_str(self):
+        expected_string = "key_1,key_2"
+        keys = ["key_1", "key_2"]
+        self.assertEqual(expected_string, make_keys_str(keys))


### PR DESCRIPTION
Strings only need to be decoded when they are instances of ``bytes``.

Added tests to explicitly tests both bytes and strs.