### PR TITLE
Add ignore_exception_cls arg to configure_error_reporting

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -625,7 +625,7 @@ class Baseplate(object):
 
         self.register(TraceBaseplateObserver(tracing_client))
 
-    def configure_error_reporting(self, client):
+    def configure_error_reporting(self, client, ignore_exception_cls=None):
         """Send reports for unexpected exceptions to the given client.
 
         This also adds a :py:class:`raven.Client` object to the ``sentry``
@@ -633,10 +633,12 @@ class Baseplate(object):
         application-specific events.
 
         :param raven.Client client: A configured raven client.
+        :param class ignore_exception_cls: If non-None, all exceptions with
+                                           matching class will be ignored.
 
         """
         from .diagnostics.sentry import SentryBaseplateObserver
-        self.register(SentryBaseplateObserver(client))
+        self.register(SentryBaseplateObserver(client, ignore_exception_cls))
 
     def add_to_context(self, name, context_factory):
         """Add an attribute to each request's context object.


### PR DESCRIPTION
Some Python frameworks allow you to raise certain exceptions to indicate
certain errors, and the framework will handle that accordingly. Those type of
exceptions are raised intentionally and reporting them to sentry would be
noisy.

Add ignore_exception_cls arg to configure_error_reporting to enable the feature
of ignoring certain exceptions.

There are in general two approaches to this problem, one is passing in an
exception class and the other is passing in a function to test against
exc_info. The latter is more flexible (it can handle the case that there are
more than one exception classes to ignore that doesn't share the same
superclass), but the former is easier and can handle 90% of the cases.