### PR TITLE
Stop error on bad config

### DIFF
--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -168,7 +168,11 @@ class Experiments(object):
         :return: Variant name if a variant is active, None otherwise.
         """
 
-        experiment = self._get_experiment(name)
+        try:
+            experiment = self._get_experiment(name)
+        except (ValueError, TypeError) as err:
+            logger.error("Invalid configiguration for experiment {}: {}".format(name, err))
+            return None
 
         if experiment is None:
             return None
@@ -228,8 +232,11 @@ class Experiments(object):
         :param kwargs: Additional arguments that will be passed to logger.
 
         """
-
-        experiment = self._get_experiment(experiment_name)
+        try:
+            experiment = self._get_experiment(name)
+        except (ValueError, TypeError) as err:
+            logger.error("Invalid configiguration for experiment {}: {}".format(name, err))
+            return None
 
         if experiment is None:
             return

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -93,7 +93,11 @@ class Experiments(object):
             if not experiment_config:
                 experiment = None
             else:
-                experiment = parse_experiment(experiment_config)
+                try:
+                    experiment = parse_experiment(experiment_config)
+                except (ValueError, TypeError, KeyError) as err:
+                    logger.error("Invalid configuration for experiment {}: {}".format(name, err))
+                    return None
             self._experiment_cache[name] = experiment
         return self._experiment_cache[name]
 
@@ -168,11 +172,7 @@ class Experiments(object):
         :return: Variant name if a variant is active, None otherwise.
         """
 
-        try:
-            experiment = self._get_experiment(name)
-        except (ValueError, TypeError, KeyError) as err:
-            logger.error("Invalid configuration for experiment {}: {}".format(name, err))
-            return None
+        experiment = self._get_experiment(name)
 
         if experiment is None:
             return None
@@ -232,11 +232,8 @@ class Experiments(object):
         :param kwargs: Additional arguments that will be passed to logger.
 
         """
-        try:
-            experiment = self._get_experiment(experiment_name)
-        except (ValueError, TypeError, KeyError) as err:
-            logger.error("Invalid configuration for experiment {}: {}".format(experiment_name, err))
-            return None
+
+        experiment = self._get_experiment(experiment_name)
 
         if experiment is None:
             return

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -95,7 +95,7 @@ class Experiments(object):
             else:
                 try:
                     experiment = parse_experiment(experiment_config)
-                except (ValueError, TypeError, KeyError) as err:
+                except Exception as err:
                     logger.error("Invalid configuration for experiment {}: {}".format(name, err))
                     return None
             self._experiment_cache[name] = experiment

--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -170,8 +170,8 @@ class Experiments(object):
 
         try:
             experiment = self._get_experiment(name)
-        except (ValueError, TypeError) as err:
-            logger.error("Invalid configiguration for experiment {}: {}".format(name, err))
+        except (ValueError, TypeError, KeyError) as err:
+            logger.error("Invalid configuration for experiment {}: {}".format(name, err))
             return None
 
         if experiment is None:
@@ -233,9 +233,9 @@ class Experiments(object):
 
         """
         try:
-            experiment = self._get_experiment(name)
-        except (ValueError, TypeError) as err:
-            logger.error("Invalid configiguration for experiment {}: {}".format(name, err))
+            experiment = self._get_experiment(experiment_name)
+        except (ValueError, TypeError, KeyError) as err:
+            logger.error("Invalid configuration for experiment {}: {}".format(experiment_name, err))
             return None
 
         if experiment is None:

--- a/tests/unit/experiments/experiment_tests.py
+++ b/tests/unit/experiments/experiment_tests.py
@@ -529,6 +529,88 @@ class TestExperiments(unittest.TestCase):
         experiments.variant("test", user=self.user)
         self.assertEqual(self.event_logger.log.call_count, 0)
 
+    def test_none_returned_on_variant_call_with_bad_id(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": "1",
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+                "experiment": {
+                    "id": 1,
+                    "name": "test",
+                    "variants": {
+                        "active": 50,
+                        "control_1": 25,
+                        "control_2": 25,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            server_span=self.mock_span,
+            context_name="test",
+            event_logger=self.event_logger,
+        )
+        self.assertEqual(self.event_logger.log.call_count, 0)
+        variant = experiments.variant("test", user=self.user)
+        self.assertEqual(variant, None)
+
+    def test_none_returned_on_variant_call_with_no_times(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "experiment": {
+                    "id": 1,
+                    "name": "test",
+                    "variants": {
+                        "active": 50,
+                        "control_1": 25,
+                        "control_2": 25,
+                    }
+                }
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            server_span=self.mock_span,
+            context_name="test",
+            event_logger=self.event_logger,
+        )
+        self.assertEqual(self.event_logger.log.call_count, 0)
+        variant = experiments.variant("test", user=self.user)
+        self.assertEqual(variant, None)
+
+    def test_none_returned_on_variant_call_with_no_experiment(self):
+        self.mock_filewatcher.get_data.return_value = {
+            "test": {
+                "id": 1,
+                "name": "test",
+                "owner": "test_owner",
+                "type": "r2",
+                "version": "1",
+                "start_ts": time.time() - THIRTY_DAYS,
+                "stop_ts": time.time() + THIRTY_DAYS,
+            }
+        }
+        experiments = Experiments(
+            config_watcher=self.mock_filewatcher,
+            server_span=self.mock_span,
+            context_name="test",
+            event_logger=self.event_logger,
+        )
+        self.assertEqual(self.event_logger.log.call_count, 0)
+        variant = experiments.variant("test", user=self.user)
+        self.assertEqual(variant, None)
+
 
 class ExperimentsClientFromConfigTests(unittest.TestCase):
     def test_make_clients(self):


### PR DESCRIPTION
Make it so that if a bad config is pushed, the parse_experiment call won't throw an exception to the caller.