### PR TITLE
Automate PyPI Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,18 @@ script:
     - sphinx-build -M doctest docs/ build/
     - sphinx-build -M spelling docs/ build/
     - make lint
+
+jobs:
+  include:
+    - stage: PyPI Release
+      python: 3.4
+      script: echo "Deploying to PyPI"
+      deploy:
+        provider: pypi
+        install: skip
+        user: reddit
+        password:
+          secure: OeCJ+XpTicmSWTSXhCF62SWyXU+63PtdYYJEMdC0Yfttm9KFnwVvy7TZ0jCALk2+0Gw39ExdfZ5yMTEVkJY+rh98nFKAiVOX3q4X/avBCKV87p8Ju+jdGpeiirNBXNOM4qN25P+hPbI+BScmApw7dFE6eEPlHdcOwr8nxrcsmfh1NApFXiTagrpqVrV3/a9QnVSVTcbUgzWyfhLEQo+GDTyB0JnKvhMPaKOVUZ1QyoxCYkkrnDbCIH8xAMirCTqjRCHS4JW15QrmibAYOTSPhYz8Jjie9MVsNfQayxKEQwHjiE0+oQmSb8f9ZlY5qFwBAFYxRiNzF9R/baebyu07gNKBJO+NOMg33Wimfo7NtF6sJI/vXY0Wt0YByvvn6hg37Ko3W9PY6z6ZIPcanRidR5ws/w6ZZOseLaZM1VG/LnIcn9wlk5uCyGWxNW6Rkw19rKnObvUbRBTMTRRaFBhYcisodgz7T1ON2Jr0g4o5wIb6zJqwA74Dq1N0AatUXeNz1yD4CxOsXm5k3pk3OBtc0ddKr048gCMv17nUMDldauGRWwK18x0gYLCie1aaHpbZ15BRZ8KuPrr/QoVSXWSxAWacf5GQjE+tqfYJ97kMATRH1udfbQEYWyELihQvz7BV9pzW59vOt5p7P1Yu7W7ZVrpmg0IcIR9gjeEftYJTxAM=
+        distributions: "bdist_wheel"
+        on:
+          tags: true

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ cover-html-dir=../build/coverage
 max-line-length = 100
 ignore = E128,E226
 exclude = baseplate/thrift/
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
These creds are just for demonstration purposes. If there is an
organizational PyPI account to use or if one of the listed Baseplate
maintainers wants to supply theirs, let's talk!

The hope here is to do smaller incremental releases and publish them to
PyPI. This would allow Reddit projects that are using wheels to make use
of new functionality and bug fixes before doing a fleetwide release.

@spladug, any help you could lend with the credentials would be much
appreciated.