### PR TITLE
Rework SQLAlchemy instrumented client to not use threadlocals

### DIFF
--- a/baseplate/context/__init__.py
+++ b/baseplate/context/__init__.py
@@ -26,6 +26,7 @@ from __future__ import unicode_literals
 from ..core import (
     BaseplateObserver,
     LocalSpan,
+    SpanObserver,
 )
 
 
@@ -52,6 +53,13 @@ class ContextObserver(BaseplateObserver):
     def on_server_span_created(self, context, server_span):
         context_attr = self.context_factory.make_object_for_context(self.name, server_span)
         setattr(context, self.name, context_attr)
+        server_span.register(ContextSpanObserver(self.name, self.context_factory))
+
+
+class ContextSpanObserver(SpanObserver):
+    def __init__(self, name, context_factory):
+        self.name = name
+        self.context_factory = context_factory
 
     def on_child_span_created(self, child_span):
         if isinstance(child_span, LocalSpan):

--- a/baseplate/context/sqlalchemy.py
+++ b/baseplate/context/sqlalchemy.py
@@ -3,8 +3,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import threading
-
 from sqlalchemy import event
 from sqlalchemy.orm import Session
 
@@ -36,34 +34,30 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
 
     """
     def __init__(self, engine):
-        self.engine = engine
-
-        # i'm not at all thrilled about this. is there another way to get
-        # request context into the event handlers without "global" state?
-        self.threadlocal = threading.local()
-
-        event.listen(engine, "before_cursor_execute", self.on_before_execute, retval=True)
-        event.listen(engine, "after_cursor_execute", self.on_after_execute)
-        event.listen(engine, "dbapi_error", self.on_dbapi_error)
+        self.engine = engine.execution_options()
+        event.listen(self.engine, "before_cursor_execute", self.on_before_execute, retval=True)
+        event.listen(self.engine, "after_cursor_execute", self.on_after_execute)
+        event.listen(self.engine, "dbapi_error", self.on_dbapi_error)
 
     def make_object_for_context(self, name, server_span):
-        self.threadlocal.context_name = name
-        self.threadlocal.server_span = server_span
-        self.threadlocal.current_span = None
-        return self.engine
+        engine = self.engine.execution_options(
+            context_name=name,
+            server_span=server_span,
+        )
+        return engine
 
     # pylint: disable=unused-argument, too-many-arguments
     def on_before_execute(self, conn, cursor, statement, parameters, context, executemany):
         """Handle the engine's before_cursor_execute event."""
-        # http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#is-the-session-thread-safe
-        assert self.threadlocal.current_span is None, \
-            "SQLAlchemy sessions cannot be used concurrently"
+        context_name = conn._execution_options["context_name"]
+        server_span = conn._execution_options["server_span"]
 
-        trace_name = "{}.{}".format(self.threadlocal.context_name, "execute")
-        span = self.threadlocal.server_span.make_child(trace_name)
+        trace_name = "{}.{}".format(context_name, "execute")
+        span = server_span.make_child(trace_name)
         span.set_tag("statement", statement)
         span.start()
-        self.threadlocal.current_span = span
+
+        conn.info["span"] = span
 
         # add a comment to the sql statement with the trace and span ids
         # this is useful for slow query logs and active query views
@@ -74,14 +68,14 @@ class SQLAlchemyEngineContextFactory(ContextFactory):
     # pylint: disable=unused-argument, too-many-arguments
     def on_after_execute(self, conn, cursor, statement, parameters, context, executemany):
         """Handle the event which happens after successful cursor execution."""
-        self.threadlocal.current_span.finish()
-        self.threadlocal.current_span = None
+        conn.info["span"].finish()
+        conn.info["span"] = None
 
     def on_dbapi_error(self, conn, cursor, statement, parameters, context, exception):
         """Handle the event which happens on exceptions during execution."""
         exc_info = (type(exception), exception, None)
-        self.threadlocal.current_span.finish(exc_info=exc_info)
-        self.threadlocal.current_span = None
+        conn.info["span"].finish(exc_info=exc_info)
+        conn.info["span"] = None
 
 
 class SQLAlchemySessionContextFactory(SQLAlchemyEngineContextFactory):

--- a/tests/unit/context/tests.py
+++ b/tests/unit/context/tests.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 
 import unittest
 
-from baseplate.context import ContextFactory, ContextObserver
+from baseplate.context import ContextFactory, ContextObserver, ContextSpanObserver
 from baseplate.core import (
     LocalSpan,
     Span,
@@ -34,7 +34,7 @@ class ContextObserverTests(unittest.TestCase):
         mock_local_span = mock.Mock(spec=LocalSpan)
         mock_local_span.component_name = 'test_component'
         mock_local_span.context = mock_context
-        observer = ContextObserver("some_attribute", mock_factory)
+        observer = ContextSpanObserver("some_attribute", mock_factory)
         observer.on_child_span_created(mock_local_span)
 
         self.assertEqual(mock_context.some_attribute,


### PR DESCRIPTION
I've always been bothered by the threadlocals I used to make the SQLAlchemy integration work. Digging through their docs again I found that `execution_options()` on an `Engine` creates a new engine that's related to the original but can carry some extra state along with it. This allows us to build nested engines that carry span state!

Unfortunately, while testing that local spans now worked with SQLAlchemy I also discovered that local spans weren't generating context-attributes at all! We were still using the ones from the the server span always. This was because the observer wasn't really set up right. I've fixed that as well.

Hopefully this will also fix the issues the Thing service has been seeing with "SQLAlchemy sessions cannot be used concurrently" errors.

Fixes #99 