### PR TITLE
Catch exceptions that happen outside server span context

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -692,7 +692,15 @@ class Baseplate(object):
         :param raven.Client client: A configured raven client.
 
         """
-        from .diagnostics.sentry import SentryBaseplateObserver
+        from .diagnostics.sentry import (
+            SentryBaseplateObserver,
+            SentryUnhandledErrorReporter,
+        )
+
+        from gevent import get_hub
+        hub = get_hub()
+        hub.print_exception = SentryUnhandledErrorReporter(hub, client)
+
         self.register(SentryBaseplateObserver(client))
 
     def add_to_context(self, name, context_factory):

--- a/baseplate/diagnostics/sentry.py
+++ b/baseplate/diagnostics/sentry.py
@@ -51,3 +51,15 @@ class SentryServerSpanObserver(ServerSpanObserver):
         if exc_info is not None:
             self.raven.captureException(exc_info=exc_info)
         self.raven.context.clear(deactivate=True)
+
+
+class SentryUnhandledErrorReporter(object):
+    """Hook into the Gevent hub and report errors outside request context."""
+
+    def __init__(self, hub, raven):
+        self.original_print_exception = getattr(hub, "print_exception")
+        self.raven = raven
+
+    def __call__(self, context, exc_type, value, tb):
+        self.raven.captureException((exc_type, value, tb))
+        self.original_print_exception(context, exc_type, value, tb)


### PR DESCRIPTION
This can occur when the framework surrounding application code crashes.
For example, when Thrift tries to serialize invalid data like an
1,000,000 in an I16. Without this error reporting it's very annoying to
debug what's going on.

By hooking into the gevent hub, we're tied to using gevent but we
already expect that in Baseplate. This should catch all unhandled
exceptions and give us visibility into them.

cc: @bsimpson63 