### PR TITLE
Remove local span on variant call

### DIFF
--- a/baseplate/experiments/__init__.py
+++ b/baseplate/experiments/__init__.py
@@ -182,9 +182,7 @@ class Experiments(object):
         if user:
             inputs.update(user.event_fields())
 
-        span_name = "{}.{}".format(self._context_name, "variant")
-        with self._span.make_child(span_name, local=True, component_name=name):
-            variant = experiment.variant(**inputs)
+        variant = experiment.variant(**inputs)
 
         bucketing_id = experiment.get_unique_id(**inputs)
 


### PR DESCRIPTION
Local spans in variant calls within the experiments are a massive drain on CPU resources on the high volume of variant calls and provide very little value in this context.

This PR removes them from the 0.28 release (similar commits will remove them from all existing releases; the corresponding commit on master will be linked here once it's up).