### PR TITLE
diagnostics/tracing: inc RemoteRecorder max_span_batch to 100

### DIFF
--- a/baseplate/diagnostics/tracing/__init__.py
+++ b/baseplate/diagnostics/tracing/__init__.py
@@ -479,7 +479,7 @@ class RemoteRecorder(BaseBatchRecorder):
                  num_conns=5,
                  num_workers=5,
                  max_queue_size=50000,
-                 max_span_batch=20,
+                 max_span_batch=100,
                  batch_wait_interval=0.5):
 
         super(RemoteRecorder, self).__init__(


### PR DESCRIPTION
Getting a lot of cassandra zipkin pool is busy connection error. Increasing max span batch per this:
https://groups.google.com/a/lists.datastax.com/forum/#!topic/java-driver-user/p3CwOL0kNrs

@cshoe @ckwang8128