### PR TITLE
Don't report expected Thrift exceptions as errors to span observers

### DIFF
--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -107,16 +107,17 @@ def baseplateify_processor(processor, logger, baseplate, edge_context_factory=No
             headers = iprot.get_headers()
             try:
                 trace_info = _extract_trace_info(headers)
-                edge_payload = headers.get(b"Edge-Request", None)
-                if edge_context_factory:
-                    edge_context = edge_context_factory.from_upstream(edge_payload)
-                    edge_context.attach_context(context)
-                else:
-                    # just attach the raw context so it gets passed on
-                    # downstream even if we don't know how to handle it.
-                    context.raw_request_context = edge_payload
             except (KeyError, ValueError):
                 trace_info = None
+
+            edge_payload = headers.get(b"Edge-Request", None)
+            if edge_context_factory:
+                edge_context = edge_context_factory.from_upstream(edge_payload)
+                edge_context.attach_context(context)
+            else:
+                # just attach the raw context so it gets passed on
+                # downstream even if we don't know how to handle it.
+                context.raw_request_context = edge_payload
 
             server_span = baseplate.make_server_span(
                 context,

--- a/tests/integration/test.thrift
+++ b/tests/integration/test.thrift
@@ -3,7 +3,5 @@ exception ExpectedException {
 }
 
 service TestService {
-    bool example_simple(),
-
-    void example_throws(1: bool crash) throws (1: ExpectedException exc),
+    bool example() throws (1: ExpectedException exc),
 }

--- a/tests/unit/context/thrift_tests.py
+++ b/tests/unit/context/thrift_tests.py
@@ -99,7 +99,7 @@ class PooledClientProxyTests(unittest.TestCase):
     def test_edge_request_headers(self, mock_enumerate):
         mock_enumerate.return_value = ["one", "two"]
 
-        child_span = self.mock_server_span.make_child().__enter__()
+        child_span = self.mock_server_span.make_child()
         child_span.context.raw_request_context = "edge_request_context"
 
         proxy = thrift.PooledClientProxy(
@@ -112,7 +112,7 @@ class PooledClientProxyTests(unittest.TestCase):
     def test_null_edge_request_headers_not_set(self, mock_enumerate):
         mock_enumerate.return_value = ["one", "two"]
 
-        child_span = self.mock_server_span.make_child().__enter__()
+        child_span = self.mock_server_span.make_child()
         child_span.context.raw_request_context = None
 
         proxy = thrift.PooledClientProxy(


### PR DESCRIPTION
Thrift exceptions defined in the IDL are effectively another form of
return value and should not be considered an RPC failure. If
applications wish to monitor rates of specific (expected) error types
they can do so themselves.

This should allow easier monitoring of error rates.

I wanted to define some proper tests for this when getting it in place and found that the test suite was really not in a good place to do that. So I took the opportunity to rewrite it to allow full end-to-end integration testing of our Thrift integrations. Coverage on existing code is increased.

The first commit was done because 1) it was asked of me in the review for the Apache Thrift code and I hadn't done it yet, and 2) it allowed decoupling some of the tests a bit better.

The final commit (the functional change) is best viewed with whitespace diffing off (?w=1) since most of the "changes" are dedenting some code.

:eyeglasses: @pacejackson @bsimpson63 