### PR TITLE
Don't throw out traces missing optional Sampled header

### DIFF
--- a/baseplate/integration/pyramid.py
+++ b/baseplate/integration/pyramid.py
@@ -154,12 +154,13 @@ class BaseplateConfigurator(object):
 
     def _get_trace_info(self, headers):
         extracted_values = TraceInfo.extract_upstream_header_values(TRACE_HEADER_NAMES, headers)
+        sampled = bool(extracted_values.get("sampled") == b"1")
         flags = extracted_values.get("flags", None)
         return TraceInfo.from_upstream(
             int(extracted_values["trace_id"]),
             int(extracted_values["parent_span_id"]),
             int(extracted_values["span_id"]),
-            True if extracted_values["sampled"] == "1" else False,
+            sampled,
             int(flags) if flags is not None else None,
         )
 

--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -78,12 +78,13 @@ class _ContextAwareHandler(object):
 
 def _extract_trace_info(headers):
     extracted_values = TraceInfo.extract_upstream_header_values(TRACE_HEADER_NAMES, headers)
+    sampled = bool(extracted_values.get("sampled") == b"1")
     flags = extracted_values.get("flags", None)
     return TraceInfo.from_upstream(
         int(extracted_values["trace_id"]),
         int(extracted_values["parent_span_id"]),
         int(extracted_values["span_id"]),
-        True if extracted_values["sampled"].decode("utf-8") == "1" else False,
+        sampled,
         int(flags) if flags is not None else None,
     )
 


### PR DESCRIPTION
46db4cd60d8aebbe7c25ea1a7343dbea3f8fdbf1 introduced a bug where we would
throw out traces that didn't have the Sampled header even though it was
optional (and our own client only sends it if non-null).

:eyeglasses: @cshoe @bsimpson63 @ckwang8128 