### PR TITLE
Vault 0.9.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ before_install:
             unzip \
             zookeeperd
     - sudo service cassandra start
-    - wget https://releases.hashicorp.com/vault/0.7.3/vault_0.7.3_linux_amd64.zip && unzip vault_0.7.3_linux_amd64.zip && ./vault server -dev -dev-root-token-id=b4c6f298-3f80-11e7-8b88-5254001e7ad3 &
+    - wget https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip && unzip vault_1.0.0_linux_amd64.zip && ./vault server -dev -dev-root-token-id=b4c6f298-3f80-11e7-8b88-5254001e7ad3 &
     - sleep 10  # cassandra takes a while to start up
 
 script:

--- a/puppet/modules/vault/manifests/init.pp
+++ b/puppet/modules/vault/manifests/init.pp
@@ -9,12 +9,12 @@ class vault {
   }
 
   exec { 'download vault zipfile':
-    command => '/usr/bin/curl -o /var/cache/vault.zip https://releases.hashicorp.com/vault/0.7.3/vault_0.7.3_linux_amd64.zip',
+    command => '/usr/bin/curl -o /var/cache/vault.zip https://releases.hashicorp.com/vault/1.0.0/vault_1.0.0_linux_amd64.zip',
     creates => '/var/cache/vault.zip',
   }
 
   exec { 'verify zipfile':
-    command => '/usr/bin/sha256sum /var/cache/vault.zip | /bin/grep 2822164d5dd347debae8b3370f73f9564a037fc18e9adcabca5907201e5aab45',
+    command => '/usr/bin/sha256sum /var/cache/vault.zip | /bin/grep 75afb647d2ebeb46aafbf147ed1f1b379f6b8c9f909550dc2d0976cf153e8aa6',
     require => Exec['download vault zipfile'],
   }
 


### PR DESCRIPTION
A [change in vault 0.9.0 removed the nonce from responses where it was not needed](https://github.com/hashicorp/vault/commit/30aab2aa2feff6dd81ca379f2489132ff5bc284a) in order to avoid logging it. I've added nonce generation to the secret fetcher so that vault doesn't make one and log it for us. I also added a bit of documentation to aid in debugging.