### PR TITLE
Get travis auto deploying to PyPI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
     only:
         - master
+        - /^v\d+\.\d+(\.\d+)?$/
 
 sudo: required
 dist: trusty


### PR DESCRIPTION
We're set up to only deploy to PyPI on tagged commits, however we only
run Travis on commits to master. Our deploy scheme is to push to master
and then gather commits into a release branch. Then we tag the release.
This means we'll need to have travis run on the release branches as
well.