### PR TITLE
Add type warning to constant_time_compare shim

### DIFF
--- a/baseplate/crypto.py
+++ b/baseplate/crypto.py
@@ -59,6 +59,11 @@ else:
         function resistant to timing attacks.
 
         """
+
+        if type(actual) != type(expected):
+            warn_deprecated("Future versions of constant_time_compare require that both "
+                "parameters are of the same type.")
+
         actual_len = len(actual)
         expected_len = len(expected)
         result = actual_len ^ expected_len


### PR DESCRIPTION
The standard library function hmac.compare_digest requires that both
parameters are of the same type (str/unicode/bytes). We did not enforce
that here in Baseplate's shim which makes upgrading harder.