### PR TITLE
thrift: Filter out magic methods from proxy methods

### DIFF
--- a/baseplate/context/thrift.py
+++ b/baseplate/context/thrift.py
@@ -46,8 +46,9 @@ class ThriftContextFactory(ContextFactory):
             "PooledClientProxy",
             (_PooledClientProxy,),
             {
-                method_name: _build_thrift_proxy_method(method_name)
-                for method_name in _enumerate_service_methods(client_cls)
+                fn_name: _build_thrift_proxy_method(fn_name)
+                for fn_name in _enumerate_service_methods(client_cls)
+                if not (fn_name.startswith('__') and fn_name.endswith('__'))
             },
         )
 


### PR DESCRIPTION
In some python implementations, e.g. pypy6-3.5, calling
_enumerate_service_methods on thrift classes will also return magic
methods, e.g. "__new__". If we don't filter them out, they will be
replaced by our pooled thrift proxy method, which relies on the
constructor to be called first, but python calls __new__ before the
constructor, so that will cause us troubles.

This should be a no-op for python implementations that does not return
magic methods in the first place.