### PR TITLE
Add concurrency monitoring gauges sent periodically

### DIFF
--- a/baseplate/core.py
+++ b/baseplate/core.py
@@ -625,6 +625,7 @@ class Baseplate(object):
     """
     def __init__(self):
         self.observers = []
+        self._metrics_client = None
 
     def register(self, observer):
         """Register an observer.
@@ -652,6 +653,7 @@ class Baseplate(object):
 
         """
         from .diagnostics.metrics import MetricsBaseplateObserver
+        self._metrics_client = metrics_client
         self.register(MetricsBaseplateObserver(metrics_client))
 
     def configure_tracing(self, tracing_client, *args, **kwargs):

--- a/baseplate/integration/pyramid/__init__.py
+++ b/baseplate/integration/pyramid/__init__.py
@@ -168,6 +168,10 @@ class BaseplateConfigurator(object):
                 trust_headers=self.trust_trace_headers,
             )
 
+    def _on_application_created(self, event):
+        # attach the baseplate object to the application the server gets
+        event.app.baseplate = self.baseplate
+
     def _on_new_request(self, event):
         request = event.request
 
@@ -225,6 +229,7 @@ class BaseplateConfigurator(object):
 
     def includeme(self, config):
         config.add_subscriber(self._on_new_request, pyramid.events.ContextFound)
+        config.add_subscriber(self._on_application_created, pyramid.events.ApplicationCreated)
 
         # Position of the tween is important. We need it to cover all code
         # that can written in the app. This means that it should be above

--- a/baseplate/server/metrics.py
+++ b/baseplate/server/metrics.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import logging
+import os
+import socket
+import time
+
+import gevent
+
+
+REPORT_INTERVAL_SECONDS = 10
+
+
+def _report_runtime_metrics(metrics_client, hostname, pid, pool):
+    try:
+        with metrics_client.batch() as batch:
+            active_requests = batch.gauge("runtime.%s.PID%s.active_requests" % (hostname, pid))
+            active_requests.replace(len(pool.greenlets))
+    except Exception as exc:
+        logging.debug("Error while generating server metrics: %s", exc)
+
+
+def _report_runtime_metrics_periodically(metrics_client, hostname, pid, pool):
+    while True:
+        now = time.time()
+        time_since_last_report = now % REPORT_INTERVAL_SECONDS
+        time_until_next_report = REPORT_INTERVAL_SECONDS - time_since_last_report
+        time.sleep(time_until_next_report)
+
+        _report_runtime_metrics(metrics_client, hostname, pid, pool)
+
+
+def start_runtime_metrics_reporter(application, pool):
+    metrics_client = application.baseplate._metrics_client
+    if not metrics_client:
+        logging.info("No metrics client configured. Server metrics will not be sent.")
+        return
+
+    hostname = socket.gethostname()
+    pid = os.getpid()
+
+    gevent.spawn(
+        _report_runtime_metrics_periodically,
+        metrics_client,
+        hostname,
+        pid,
+        pool,
+    )

--- a/baseplate/server/thrift.py
+++ b/baseplate/server/thrift.py
@@ -14,6 +14,7 @@ from thrift.transport.TTransport import (
     TTransportException, TBufferedTransportFactory)
 
 from baseplate import config
+from baseplate.server.metrics import start_runtime_metrics_reporter
 
 
 # pylint: disable=too-many-public-methods
@@ -67,4 +68,6 @@ def make_server(server_config, listener, app):
         spawn=pool,
     )
     server.stop_timeout = cfg.stop_timeout
+
+    start_runtime_metrics_reporter(app, pool)
     return server

--- a/baseplate/server/wsgi.py
+++ b/baseplate/server/wsgi.py
@@ -11,6 +11,7 @@ from gevent.pywsgi import WSGIServer
 
 from . import _load_factory
 from baseplate import config
+from baseplate.server.metrics import start_runtime_metrics_reporter
 
 try:
     # pylint: disable=no-name-in-module
@@ -57,4 +58,6 @@ def make_server(server_config, listener, app):
         **kwargs
     )
     server.stop_timeout = cfg.stop_timeout
+
+    start_runtime_metrics_reporter(app, pool)
     return server


### PR DESCRIPTION
Baseplate servers will now report concurrent in-flight requests as a
per-hostname-per-PID gauge every 10 seconds if metrics are configured.

The metrics system should handle aggregation appropriately.

:eyeglasses: @ckwang8128 @bsimpson63 