### PR TITLE
Be case-insensitive with Thrift headers

### DIFF
--- a/baseplate/integration/thrift/__init__.py
+++ b/baseplate/integration/thrift/__init__.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 import sys
 
+from requests.structures import CaseInsensitiveDict
 from thrift.Thrift import TException, TApplicationException
 from thrift.transport.TTransport import TTransportException
 from thrift.protocol.TProtocol import TProtocolException
@@ -105,7 +106,9 @@ def baseplateify_processor(processor, logger, baseplate, edge_context_factory=No
         def call_processor_with_span_context(self, seqid, iprot, oprot):
             context = RequestContext()
 
-            headers = iprot.get_headers()
+            # Allow case-insensitivity for THeader headers
+            headers = CaseInsensitiveDict(data=iprot.get_headers())
+
             try:
                 trace_info = _extract_trace_info(headers)
             except (KeyError, ValueError):


### PR DESCRIPTION
There is currently no official spec for Thrift header
case-sensitivity. This follows Pyramid's approach of storing
HTTP headers in case-insensitive dictionary with Thrift
headers to be lenient in accepted header values while
still propagating headers in the format that they came in.

For reference:

The Pyramid implementation details - https://github.com/Pylons/pyramid/blob/c02f228b554d636d475ad1f34945fd91e4b1bfdf/docs/narr/webob.rst (see `req.headers`) 

The requests CaseInsensitiveDict module - https://github.com/kennethreitz/requests/blob/v1.2.3/requests/structures.py#L37 

The fbthrift header object - https://github.com/apache/thrift/blob/66a44c5d8d57bd0c2e2afd228a29b5bc679a6770/lib/py/src/transport/THeaderTransport.py#L96 